### PR TITLE
Update tags in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === AI Provider for OpenAI ===
 Contributors: wordpressdotorg
-Tags: ai, openai, gpt, chatgpt, artificial-intelligence
+Tags: ai, openai, gpt, artificial-intelligence, connector
 Requires at least: 6.9
 Tested up to: 7.0
 Stable tag: 1.0.1


### PR DESCRIPTION
Based on the recommendation in https://github.com/WordPress/gutenberg/pull/75833#issuecomment-3947453337 looking to add this tag so that this provider plugin (and others using the same tag) will populate into the linked WP Admin/WPORG plugin search results.  Also removes the chatgpt tag to allow for the connector tag to be added (there's a max of 5) which feels ok as gpt still remains but happy to replace gpt with chatgpt if desired.