### PR TITLE
Add image editing support for `gpt-image-*` models

### DIFF
--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -129,6 +129,10 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
         $imageCapabilities = [
             CapabilityEnum::imageGeneration(),
         ];
+        $gptImageCapabilities = [
+            CapabilityEnum::imageGeneration(),
+            CapabilityEnum::chatHistory(),
+        ];
         $dalleImageOptions = [
             new SupportedOption(OptionEnum::inputModalities(), [[ModalityEnum::text()]]),
             new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::image()]]),
@@ -144,7 +148,10 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
             new SupportedOption(OptionEnum::customOptions()),
         ];
         $gptImageOptions = [
-            new SupportedOption(OptionEnum::inputModalities(), [[ModalityEnum::text()]]),
+            new SupportedOption(OptionEnum::inputModalities(), [
+                [ModalityEnum::text()],
+                [ModalityEnum::text(), ModalityEnum::image()],
+            ]),
             new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::image()]]),
             new SupportedOption(OptionEnum::candidateCount()),
             new SupportedOption(OptionEnum::outputMimeType(), ['image/png', 'image/jpeg', 'image/webp']),
@@ -185,22 +192,19 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     $gptMultimodalSpeechOutputOptions,
                     $gptSearchOptions,
                     $imageCapabilities,
+                    $gptImageCapabilities,
                     $dalleImageOptions,
                     $gptImageOptions,
                     $ttsCapabilities,
                     $ttsOptions
                 ): ModelMetadata {
                     $modelId = $modelData['id'];
-                    if (
-                        str_starts_with($modelId, 'dall-e-') ||
-                        str_starts_with($modelId, 'gpt-image-')
-                    ) {
+                    if (str_starts_with($modelId, 'gpt-image-')) {
+                        $modelCaps = $gptImageCapabilities;
+                        $modelOptions = $gptImageOptions;
+                    } elseif (str_starts_with($modelId, 'dall-e-')) {
                         $modelCaps = $imageCapabilities;
-                        if (str_starts_with($modelId, 'gpt-image-')) {
-                            $modelOptions = $gptImageOptions;
-                        } else {
-                            $modelOptions = $dalleImageOptions;
-                        }
+                        $modelOptions = $dalleImageOptions;
                     } elseif (
                         str_starts_with($modelId, 'tts-') ||
                         str_contains($modelId, '-tts')

--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -129,14 +129,6 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
         $imageCapabilities = [
             CapabilityEnum::imageGeneration(),
         ];
-        $gptImageCapabilities = [
-            CapabilityEnum::imageGeneration(),
-            CapabilityEnum::chatHistory(),
-        ];
-        $dalle2Capabilities = [
-            CapabilityEnum::imageGeneration(),
-            CapabilityEnum::chatHistory(),
-        ];
         $dalle2Options = [
             new SupportedOption(OptionEnum::inputModalities(), [
                 [ModalityEnum::text()],
@@ -209,9 +201,7 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     $gptMultimodalSpeechOutputOptions,
                     $gptSearchOptions,
                     $imageCapabilities,
-                    $gptImageCapabilities,
                     $gptImageOptions,
-                    $dalle2Capabilities,
                     $dalle2Options,
                     $dalle3Options,
                     $ttsCapabilities,
@@ -222,10 +212,10 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                         str_starts_with($modelId, 'gpt-image-') ||
                         str_starts_with($modelId, 'chatgpt-image-')
                     ) {
-                        $modelCaps = $gptImageCapabilities;
+                        $modelCaps = $imageCapabilities;
                         $modelOptions = $gptImageOptions;
                     } elseif ($modelId === 'dall-e-2') {
-                        $modelCaps = $dalle2Capabilities;
+                        $modelCaps = $imageCapabilities;
                         $modelOptions = $dalle2Options;
                     } elseif (str_starts_with($modelId, 'dall-e-')) {
                         $modelCaps = $imageCapabilities;

--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -133,7 +133,24 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
             CapabilityEnum::imageGeneration(),
             CapabilityEnum::chatHistory(),
         ];
-        $dalleImageOptions = [
+        $dalle2Capabilities = [
+            CapabilityEnum::imageGeneration(),
+            CapabilityEnum::chatHistory(),
+        ];
+        $dalle2Options = [
+            new SupportedOption(OptionEnum::inputModalities(), [
+                [ModalityEnum::text()],
+                [ModalityEnum::text(), ModalityEnum::image()],
+            ]),
+            new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::image()]]),
+            new SupportedOption(OptionEnum::candidateCount()),
+            new SupportedOption(OptionEnum::outputMimeType(), ['image/png']),
+            new SupportedOption(OptionEnum::outputFileType(), [FileTypeEnum::inline(), FileTypeEnum::remote()]),
+            new SupportedOption(OptionEnum::outputMediaOrientation(), [MediaOrientationEnum::square()]),
+            new SupportedOption(OptionEnum::outputMediaAspectRatio(), ['1:1']),
+            new SupportedOption(OptionEnum::customOptions()),
+        ];
+        $dalle3Options = [
             new SupportedOption(OptionEnum::inputModalities(), [[ModalityEnum::text()]]),
             new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::image()]]),
             new SupportedOption(OptionEnum::candidateCount()),
@@ -193,18 +210,26 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     $gptSearchOptions,
                     $imageCapabilities,
                     $gptImageCapabilities,
-                    $dalleImageOptions,
                     $gptImageOptions,
+                    $dalle2Capabilities,
+                    $dalle2Options,
+                    $dalle3Options,
                     $ttsCapabilities,
                     $ttsOptions
                 ): ModelMetadata {
                     $modelId = $modelData['id'];
-                    if (str_starts_with($modelId, 'gpt-image-')) {
+                    if (
+                        str_starts_with($modelId, 'gpt-image-') ||
+                        str_starts_with($modelId, 'chatgpt-image-')
+                    ) {
                         $modelCaps = $gptImageCapabilities;
                         $modelOptions = $gptImageOptions;
+                    } elseif ($modelId === 'dall-e-2') {
+                        $modelCaps = $dalle2Capabilities;
+                        $modelOptions = $dalle2Options;
                     } elseif (str_starts_with($modelId, 'dall-e-')) {
                         $modelCaps = $imageCapabilities;
-                        $modelOptions = $dalleImageOptions;
+                        $modelOptions = $dalle3Options;
                     } elseif (
                         str_starts_with($modelId, 'tts-') ||
                         str_contains($modelId, '-tts')

--- a/src/Models/OpenAiImageGenerationModel.php
+++ b/src/Models/OpenAiImageGenerationModel.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace WordPress\OpenAiAiProvider\Models;
 
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleImageGenerationModel;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 /**
@@ -16,10 +20,41 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  * This uses the Images API directly to generate images with GPT image models
  * (gpt-image-1, etc.) and DALL-E models (dall-e-2, dall-e-3).
  *
+ * GPT image models also support image editing via the `/images/edits` endpoint.
+ * Editing is triggered when a multi-message prompt is provided (a model message
+ * with the source image and a user message with edit instructions).
+ *
  * @since 1.0.0
  */
 class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGenerationModel
 {
+    /**
+     * {@inheritDoc}
+     *
+     * Routes multi-message prompts for GPT image models to the `/images/edits` endpoint
+     * instead of `/images/generations`.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt The prompt to generate or edit an image for.
+     * @return GenerativeAiResult The generative AI result.
+     * @throws InvalidArgumentException If multi-message prompts are used with a non-gpt-image model.
+     */
+    public function generateImageResult(array $prompt): GenerativeAiResult
+    {
+        if (count($prompt) === 1) {
+            return parent::generateImageResult($prompt);
+        }
+
+        if (!$this->isGptImageModel($this->metadata()->getId())) {
+            throw new InvalidArgumentException(
+                'Image editing via multi-message prompts is only supported for gpt-image-* models.'
+            );
+        }
+
+        return $this->generateImageEditResult($prompt);
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -139,6 +174,201 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
 
         // Default to square.
         return '1024x1024';
+    }
+
+    /**
+     * Generates an image edit result using the `/images/edits` endpoint.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt A multi-message prompt containing the source image and edit instructions.
+     * @return GenerativeAiResult The generative AI result containing the edited image.
+     * @throws InvalidArgumentException If the prompt does not contain a valid image or text instruction.
+     */
+    protected function generateImageEditResult(array $prompt): GenerativeAiResult
+    {
+        $editData = $this->extractEditData($prompt);
+        $params = $this->prepareEditParams($editData['text']);
+
+        $boundary = bin2hex(random_bytes(16));
+        $body = $this->buildMultipartBody($params, $editData['image'], $boundary);
+
+        $request = $this->createRequest(
+            HttpMethodEnum::POST(),
+            'images/edits',
+            ['Content-Type' => 'multipart/form-data; boundary=' . $boundary],
+            $body
+        );
+
+        $request = $this->getRequestAuthentication()->authenticateRequest($request);
+
+        $response = $this->getHttpTransporter()->send($request);
+        $this->throwIfNotSuccessful($response);
+
+        $outputFormat = isset($params['output_format']) && is_string($params['output_format'])
+            ? $params['output_format']
+            : 'png';
+
+        return $this->parseResponseToGenerativeAiResult($response, 'image/' . $outputFormat);
+    }
+
+    /**
+     * Extracts the source image file and edit text instruction from a multi-message prompt.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt The multi-message prompt to extract data from.
+     * @return array{image: File, text: string} The extracted image file and text instruction.
+     * @throws InvalidArgumentException If no image or no user text instruction is found.
+     */
+    protected function extractEditData(array $prompt): array
+    {
+        $imageFile = null;
+        $textPrompt = null;
+
+        foreach ($prompt as $message) {
+            foreach ($message->getParts() as $part) {
+                if ($imageFile === null) {
+                    $file = $part->getFile();
+                    if ($file !== null && $file->isImage()) {
+                        $imageFile = $file;
+                    }
+                }
+
+                if ($textPrompt === null && $message->getRole()->isUser()) {
+                    $text = $part->getText();
+                    if ($text !== null) {
+                        $textPrompt = $text;
+                    }
+                }
+            }
+        }
+
+        if ($imageFile === null) {
+            throw new InvalidArgumentException(
+                'The prompt must contain an image file to edit.'
+            );
+        }
+
+        if ($textPrompt === null) {
+            throw new InvalidArgumentException(
+                'The prompt must contain a user message with text instructions for the edit.'
+            );
+        }
+
+        return ['image' => $imageFile, 'text' => $textPrompt];
+    }
+
+    /**
+     * Prepares the parameters for an image edit request.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $textPrompt The text instruction for the edit.
+     * @return array<string, mixed> The parameters for the API request.
+     * @throws InvalidArgumentException If a custom option conflicts with an existing parameter.
+     */
+    protected function prepareEditParams(string $textPrompt): array
+    {
+        $config = $this->getConfig();
+
+        $params = [
+            'model' => $this->metadata()->getId(),
+            'prompt' => $textPrompt,
+        ];
+
+        $candidateCount = $config->getCandidateCount();
+        if ($candidateCount !== null) {
+            $params['n'] = $candidateCount;
+        }
+
+        $outputMimeType = $config->getOutputMimeType();
+        if ($outputMimeType !== null) {
+            $params['output_format'] = (string) preg_replace('/^image\//', '', $outputMimeType);
+        }
+
+        $outputMediaOrientation = $config->getOutputMediaOrientation();
+        $outputMediaAspectRatio = $config->getOutputMediaAspectRatio();
+        if ($outputMediaOrientation !== null || $outputMediaAspectRatio !== null) {
+            $params['size'] = $this->prepareGptImageSizeParam($outputMediaOrientation, $outputMediaAspectRatio);
+        }
+
+        $customOptions = $config->getCustomOptions();
+        foreach ($customOptions as $key => $value) {
+            if (isset($params[$key])) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'The custom option "%s" conflicts with an existing parameter.',
+                        $key
+                    )
+                );
+            }
+            $params[$key] = $value;
+        }
+
+        return $params;
+    }
+
+    /**
+     * Builds a multipart/form-data body from the given parameters and image file.
+     *
+     * Only inline (base64) images are supported. The `/images/edits` endpoint requires
+     * the image to be uploaded as binary file data; remote URLs cannot be sent directly.
+     * In practice this is not a limitation for the edit flow, since gpt-image-* models
+     * always return inline images.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $params The scalar form fields to include.
+     * @param File $imageFile The source image file to include. Must be an inline (base64) image.
+     * @param string $boundary The multipart boundary string.
+     * @return string The raw multipart/form-data body.
+     * @throws InvalidArgumentException If the image is remote, has no base64 data, or cannot be decoded.
+     */
+    protected function buildMultipartBody(array $params, File $imageFile, string $boundary): string
+    {
+        if ($imageFile->isRemote()) {
+            throw new InvalidArgumentException(
+                'Remote image URLs are not supported for image editing. Please provide an inline (base64) image.'
+            );
+        }
+
+        $base64Data = $imageFile->getBase64Data();
+        if ($base64Data === null) {
+            throw new InvalidArgumentException(
+                'The image file has no base64 data.'
+            );
+        }
+
+        $binaryData = base64_decode($base64Data, true);
+        if ($binaryData === false) {
+            throw new InvalidArgumentException(
+                'Failed to decode the base64 image data.'
+            );
+        }
+
+        $ext = (string) str_replace(
+            ['image/jpeg', 'image/'],
+            ['jpg', ''],
+            $imageFile->getMimeType()
+        );
+
+        $body = '';
+
+        foreach ($params as $key => $value) {
+            /** @var scalar $value */
+            $body .= '--' . $boundary . "\r\n";
+            $body .= 'Content-Disposition: form-data; name="' . $key . '"' . "\r\n\r\n";
+            $body .= (string) $value . "\r\n";
+        }
+
+        $body .= '--' . $boundary . "\r\n";
+        $body .= 'Content-Disposition: form-data; name="image"; filename="image.' . $ext . '"' . "\r\n";
+        $body .= 'Content-Type: ' . $imageFile->getMimeType() . "\r\n\r\n";
+        $body .= $binaryData . "\r\n";
+        $body .= '--' . $boundary . '--' . "\r\n";
+
+        return $body;
     }
 
     /**

--- a/src/Models/OpenAiImageGenerationModel.php
+++ b/src/Models/OpenAiImageGenerationModel.php
@@ -18,11 +18,11 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  * Class for an OpenAI image generation model using the Images API.
  *
  * This uses the Images API directly to generate images with GPT image models
- * (gpt-image-1, etc.) and DALL-E models (dall-e-2, dall-e-3).
+ * (gpt-image-1, chatgpt-image-latest, etc.) and DALL-E models (dall-e-2, dall-e-3).
  *
- * GPT image models also support image editing via the `/images/edits` endpoint.
- * Editing is triggered when a multi-message prompt is provided (a model message
- * with the source image and a user message with edit instructions).
+ * GPT image models and DALL-E 2 also support image editing via the `/images/edits`
+ * endpoint. Editing is triggered when a multi-message prompt is provided (a model
+ * message with the source image and a user message with edit instructions).
  *
  * @since 1.0.0
  */
@@ -31,25 +31,19 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     /**
      * {@inheritDoc}
      *
-     * Routes multi-message prompts for GPT image models to the `/images/edits` endpoint
-     * instead of `/images/generations`.
+     * Routes multi-message prompts to the `/images/edits` endpoint instead of
+     * `/images/generations`. Only models declaring the `chatHistory` capability
+     * will receive multi-message prompts from the SDK.
      *
      * @since n.e.x.t
      *
      * @param list<Message> $prompt The prompt to generate or edit an image for.
      * @return GenerativeAiResult The generative AI result.
-     * @throws InvalidArgumentException If multi-message prompts are used with a non-gpt-image model.
      */
     public function generateImageResult(array $prompt): GenerativeAiResult
     {
-        if (count($prompt) === 1) {
+        if (count($prompt) <= 1) {
             return parent::generateImageResult($prompt);
-        }
-
-        if (!$this->isGptImageModel($this->metadata()->getId())) {
-            throw new InvalidArgumentException(
-                'Image editing via multi-message prompts is only supported for gpt-image-* models.'
-            );
         }
 
         return $this->generateImageEditResult($prompt);
@@ -129,6 +123,9 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     /**
      * Checks if the given model ID is a GPT image model.
      *
+     * This includes both `gpt-image-*` and `chatgpt-image-*` model families,
+     * which share the same API capabilities and parameter format.
+     *
      * @since 1.0.0
      *
      * @param string $modelId The model ID to check.
@@ -136,7 +133,8 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
      */
     protected function isGptImageModel(string $modelId): bool
     {
-        return str_starts_with($modelId, 'gpt-image-');
+        return str_starts_with($modelId, 'gpt-image-')
+            || str_starts_with($modelId, 'chatgpt-image-');
     }
 
     /**
@@ -205,11 +203,18 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
         $response = $this->getHttpTransporter()->send($request);
         $this->throwIfNotSuccessful($response);
 
-        $outputFormat = isset($params['output_format']) && is_string($params['output_format'])
-            ? $params['output_format']
-            : 'png';
+        // Determine output MIME type based on model family.
+        if ($this->isGptImageModel($this->metadata()->getId())) {
+            $outputFormat = isset($params['output_format']) && is_string($params['output_format'])
+                ? $params['output_format']
+                : 'png';
+            $outputMimeType = 'image/' . $outputFormat;
+        } else {
+            // DALL-E 2 always returns PNG.
+            $outputMimeType = 'image/png';
+        }
 
-        return $this->parseResponseToGenerativeAiResult($response, 'image/' . $outputFormat);
+        return $this->parseResponseToGenerativeAiResult($response, $outputMimeType);
     }
 
     /**
@@ -262,6 +267,10 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     /**
      * Prepares the parameters for an image edit request.
      *
+     * Parameter handling differs by model family:
+     * - GPT image models use `output_format` and `prepareGptImageSizeParam()` sizes.
+     * - DALL-E 2 uses `response_format` (url/b64_json) and `prepareDalleSizeParam()` sizes.
+     *
      * @since n.e.x.t
      *
      * @param string $textPrompt The text instruction for the edit.
@@ -271,9 +280,11 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     protected function prepareEditParams(string $textPrompt): array
     {
         $config = $this->getConfig();
+        $modelId = $this->metadata()->getId();
+        $isGptImage = $this->isGptImageModel($modelId);
 
         $params = [
-            'model' => $this->metadata()->getId(),
+            'model' => $modelId,
             'prompt' => $textPrompt,
         ];
 
@@ -282,17 +293,39 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
             $params['n'] = $candidateCount;
         }
 
-        $outputMimeType = $config->getOutputMimeType();
-        if ($outputMimeType !== null) {
-            $params['output_format'] = (string) preg_replace('/^image\//', '', $outputMimeType);
-        }
-
+        // Size handling differs by model family.
         $outputMediaOrientation = $config->getOutputMediaOrientation();
         $outputMediaAspectRatio = $config->getOutputMediaAspectRatio();
         if ($outputMediaOrientation !== null || $outputMediaAspectRatio !== null) {
-            $params['size'] = $this->prepareGptImageSizeParam($outputMediaOrientation, $outputMediaAspectRatio);
+            if ($isGptImage) {
+                $params['size'] = $this->prepareGptImageSizeParam($outputMediaOrientation, $outputMediaAspectRatio);
+            } else {
+                $params['size'] = $this->prepareDalleSizeParam(
+                    $modelId,
+                    $outputMediaOrientation,
+                    $outputMediaAspectRatio
+                );
+            }
         }
 
+        // Output format handling differs by model family.
+        if ($isGptImage) {
+            // GPT image models use output_format (png, jpeg, webp).
+            $outputMimeType = $config->getOutputMimeType();
+            if ($outputMimeType !== null) {
+                $params['output_format'] = (string) preg_replace('/^image\//', '', $outputMimeType);
+            }
+        } else {
+            // DALL-E 2 uses response_format (url or b64_json).
+            $outputFileType = $config->getOutputFileType();
+            if ($outputFileType !== null && $outputFileType->isRemote()) {
+                $params['response_format'] = 'url';
+            } else {
+                $params['response_format'] = 'b64_json';
+            }
+        }
+
+        // Custom options (e.g., quality, background, mask for GPT models).
         $customOptions = $config->getCustomOptions();
         foreach ($customOptions as $key => $value) {
             if (isset($params[$key])) {

--- a/src/Models/OpenAiImageGenerationModel.php
+++ b/src/Models/OpenAiImageGenerationModel.php
@@ -21,8 +21,8 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  * (gpt-image-1, chatgpt-image-latest, etc.) and DALL-E models (dall-e-2, dall-e-3).
  *
  * GPT image models and DALL-E 2 also support image editing via the `/images/edits`
- * endpoint. Editing is triggered when a multi-message prompt is provided (a model
- * message with the source image and a user message with edit instructions).
+ * endpoint. Editing is triggered when the prompt message contains an image file
+ * alongside the text instruction (i.e. a `[text, image]` input modality).
  *
  * @since 1.0.0
  */
@@ -31,9 +31,9 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     /**
      * {@inheritDoc}
      *
-     * Routes multi-message prompts to the `/images/edits` endpoint instead of
-     * `/images/generations`. Only models declaring the `chatHistory` capability
-     * will receive multi-message prompts from the SDK.
+     * When the prompt contains an image file (text + image input), the request is
+     * routed to the `/images/edits` endpoint instead of `/images/generations`.
+     * This supports GPT image models (gpt-image-*, chatgpt-image-*) and DALL-E 2.
      *
      * @since n.e.x.t
      *
@@ -42,11 +42,32 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
      */
     public function generateImageResult(array $prompt): GenerativeAiResult
     {
-        if (count($prompt) <= 1) {
-            return parent::generateImageResult($prompt);
+        if ($this->promptContainsImage($prompt)) {
+            return $this->generateImageEditResult($prompt);
         }
 
-        return $this->generateImageEditResult($prompt);
+        return parent::generateImageResult($prompt);
+    }
+
+    /**
+     * Checks whether any message in the prompt contains an image file.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt The prompt messages to check.
+     * @return bool True if the prompt contains at least one image file.
+     */
+    protected function promptContainsImage(array $prompt): bool
+    {
+        foreach ($prompt as $message) {
+            foreach ($message->getParts() as $part) {
+                $file = $part->getFile();
+                if ($file !== null && $file->isImage()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -177,9 +198,12 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     /**
      * Generates an image edit result using the `/images/edits` endpoint.
      *
+     * The prompt should contain a single user message with both text (the edit instruction)
+     * and an image file (the source image to edit).
+     *
      * @since n.e.x.t
      *
-     * @param list<Message> $prompt A multi-message prompt containing the source image and edit instructions.
+     * @param list<Message> $prompt The prompt containing the source image and edit instructions.
      * @return GenerativeAiResult The generative AI result containing the edited image.
      * @throws InvalidArgumentException If the prompt does not contain a valid image or text instruction.
      */
@@ -218,11 +242,15 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     }
 
     /**
-     * Extracts the source image file and edit text instruction from a multi-message prompt.
+     * Extracts the source image file and edit text instruction from the prompt.
+     *
+     * Iterates all message parts to find the first image file and the first text part.
+     * Both are expected within a single user message, but this method is lenient about
+     * the message structure to allow flexibility.
      *
      * @since n.e.x.t
      *
-     * @param list<Message> $prompt The multi-message prompt to extract data from.
+     * @param list<Message> $prompt The prompt to extract data from.
      * @return array{image: File, text: string} The extracted image file and text instruction.
      * @throws InvalidArgumentException If no image or no user text instruction is found.
      */
@@ -389,7 +417,11 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
         $body = '';
 
         foreach ($params as $key => $value) {
-            /** @var scalar $value */
+            if (!is_scalar($value)) {
+                throw new InvalidArgumentException(
+                    sprintf('The parameter "%s" must be a scalar value for multipart requests.', $key)
+                );
+            }
             $body .= '--' . $boundary . "\r\n";
             $body .= 'Content-Disposition: form-data; name="' . $key . '"' . "\r\n\r\n";
             $body .= (string) $value . "\r\n";


### PR DESCRIPTION
## What
Closes #8

Adds support for OpenAI's `/images/edits` endpoint, enabling image editing on `gpt-image-*` models (e.g. `gpt-image-1`). DALL-E models are unchanged.

## How
**Metadata (`OpenAiModelMetadataDirectory`)**

`gpt-image-*` models now declare:
- capabilities: `[imageGeneration, chatHistory]` (previously `[imageGeneration]` only)
- input modalities: `[[text], [text, image]]` (previously `[text]` only)

This is the same capability signal the Google provider already uses for Gemini image refinement — any provider wanting to support image editing can adopt the same pattern, making this approach generic rather than OpenAI-specific.

`dall-e-*` models retain `[imageGeneration]` with text-only input and are unaffected.

**Model (`OpenAiImageGenerationModel`)**

`generateImageResult()` is overridden to route based on prompt shape:

- **Single message** → delegates to `parent::generateImageResult()` (existing `/images/generations` path, no behaviour change)
- **Multi-message + `gpt-image-*`** → routes to new `generateImageEditResult()` which calls `/images/edits`
- **Multi-message + DALL-E** → throws `InvalidArgumentException` (DALL-E doesn't support edits)

The edit prompt shape follows the existing chat history convention: a `model`-role message containing the source image, followed by a `user`-role message with the edit instruction. This is the same shape `ModelRequirements::fromPromptData()` already uses to require `chatHistory`.

The `/images/edits` endpoint expects `multipart/form-data` rather than JSON. The body is built manually and passed to `Request` as a raw string, which the SDK already supports. Only inline (base64) images are accepted — remote URLs cannot be uploaded as binary to this endpoint, and `gpt-image-*` output is already declared as `inline`-only, so this is not a practical limitation for the primary use case.

## Files changed
| File | Change |
|------|--------|
| `src/Metadata/OpenAiModelMetadataDirectory.php` | Add `$gptImageCapabilities`; expand `gpt-image-*` input modalities; separate `gpt-image` and `dall-e` routing |
| `src/Models/OpenAiImageGenerationModel.php` | Override `generateImageResult()`; add `generateImageEditResult()`, `extractEditData()`, `prepareEditParams()`, `buildMultipartBody()` |
