### PR TITLE
Add support for fine-tuned models

### DIFF
--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -191,6 +191,17 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     $ttsOptions
                 ): ModelMetadata {
                     $modelId = $modelData['id'];
+
+                    // Fine-tuned models use the format "ft:{base_model}:{org}:{name}:{id}".
+                    // Extract the base model ID for capability detection, but keep the
+                    // original model ID for the metadata so API requests use the fine-tuned model.
+                    if (str_starts_with($modelId, 'ft:')) {
+                        $parts = explode(':', $modelId, 3);
+                        if (isset($parts[1])) {
+                            $modelId = $parts[1];
+                        }
+                    }
+
                     if (
                         str_starts_with($modelId, 'dall-e-') ||
                         str_starts_with($modelId, 'gpt-image-')
@@ -234,8 +245,8 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     }
 
                     return new ModelMetadata(
-                        $modelId,
-                        $modelId, // The OpenAI API does not return a display name.
+                        $modelData['id'],
+                        $modelData['id'], // The OpenAI API does not return a display name.
                         $modelCaps,
                         $modelOptions
                     );

--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -195,6 +195,7 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     // Fine-tuned models use the format "ft:{base_model}:{org}:{name}:{id}".
                     // Extract the base model ID for capability detection, but keep the
                     // original model ID for the metadata so API requests use the fine-tuned model.
+                    $originalModelId = $modelId;
                     if (str_starts_with($modelId, 'ft:')) {
                         $parts = explode(':', $modelId, 3);
                         if (isset($parts[1])) {
@@ -245,8 +246,8 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     }
 
                     return new ModelMetadata(
-                        $modelData['id'],
-                        $modelData['id'], // The OpenAI API does not return a display name.
+                        $originalModelId,
+                        $originalModelId, // The OpenAI API does not return a display name.
                         $modelCaps,
                         $modelOptions
                     );


### PR DESCRIPTION
Fine-tuned models (`ft:gpt-4o-mini:...`) get empty capabilities because the `ft:` prefix doesn't match any capability detection branch. This makes them unusable through both auto-discovery and explicit model selection via `getProviderModel()`.

This extracts the base model ID from the `ft:` prefix for capability detection while keeping the original model ID in the metadata for API requests.