### PR TITLE
Better mapping of models that support multimodal inputs

### DIFF
--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -208,11 +208,18 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                         $modelCaps = $ttsCapabilities;
                         $modelOptions = $ttsOptions;
                     } elseif (
-                        (str_starts_with($modelId, 'gpt-') || str_starts_with($modelId, 'o1-'))
+                        (
+                            str_starts_with($modelId, 'gpt-')
+                            || str_starts_with($modelId, 'o1')
+                            || str_starts_with($modelId, 'o3')
+                            || str_starts_with($modelId, 'o4')
+                            || $modelId === 'codex-mini-latest'
+                        )
                         && !str_contains($modelId, '-instruct')
                         && !str_contains($modelId, '-realtime')
+                        && !str_contains($modelId, '-transcribe')
                     ) {
-                        if (str_starts_with($modelId, 'gpt-4o')) {
+                        if (self::supportsMultimodalTextInput($modelId)) {
                             $modelCaps = $gptCapabilities;
                             $modelOptions = $gptMultimodalInputOptions;
                             // New multimodal output model for audio generation.
@@ -247,6 +254,22 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
         usort($models, [$this, 'modelSortCallback']);
 
         return $models;
+    }
+
+    /**
+     * Checks whether an OpenAI text generation model supports multimodal input.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $modelId The model ID.
+     * @return bool True if the model supports multimodal text input, false otherwise.
+     */
+    private static function supportsMultimodalTextInput(string $modelId): bool
+    {
+        return (bool) preg_match(
+            '/^(codex-mini-latest|gpt-4-turbo|gpt-4o|gpt-4\.1|gpt-5(?:\.\d+)?|o1|o3|o4)/',
+            $modelId
+        );
     }
 
     /**


### PR DESCRIPTION
## What?

Closes #21

Ensure we support a wider-range of models for multimodal input

## Why?

At the moment it seems the only models we return when someone wants a model that supports multimodal inputs is `gpt-4o*` models, even though OpenAI has lots of other models that will work for this request. We also only consider `o1*` models though there's `o3*` and `o4*` models now.

This PR updates our mapping logic to better support a wider range of models.

## How?

- Expand our initial check from just `gpt-4o` and `o1` models to also include `o3` and `o4` and exclude `-transcribe`
- Add a new helper method, `supportsMultimodalTextInput`, and use that to determine if a model ID is supported for multimodal input. This method matches on a wider range of model IDs, including `gpt-4.1*` and `gpt-5*` models

### Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): GPT-5.5
Used for: Validate the bug and propose a fix. Manual testing done by me
