### PR TITLE
Add ChatGPT Codex provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ The provider uses the `OPENAI_API_KEY` environment variable for authentication. 
 putenv('OPENAI_API_KEY=your-api-key');
 ```
 
+### Codex OAuth
+
+The plugin also registers a `codex` provider for ChatGPT subscription-backed Codex access. Codex uses OAuth token data instead of an OpenAI Platform API key.
+
+In WordPress, token data can be supplied with the `ai_provider_openai_codex_oauth_tokens` option or filter. The expected shape is:
+
+```php
+[
+    'refresh_token' => '...',
+    'access_token'  => '...', // Optional; refreshed automatically when expired.
+    'expires_at'    => time() + 3600,
+    'account_id'    => '...', // Optional ChatGPT workspace/account ID.
+    'fedramp'       => false, // Optional.
+]
+```
+
+Constants are also supported for local configuration:
+
+```php
+define('AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN', '...');
+define('AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID', '...');
+```
+
+Codex models are available through the `codex` provider, for example `gpt-5.5`, `gpt-5`, and `codex-mini-latest`.
+
 ## License
 
 GPL-2.0-or-later

--- a/composer.lock
+++ b/composer.lock
@@ -1147,9 +1147,9 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/plugin.php
+++ b/plugin.php
@@ -21,10 +21,7 @@ declare(strict_types=1);
 namespace WordPress\OpenAiAiProvider;
 
 use WordPress\AiClient\AiClient;
-use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
 use WordPress\OpenAiAiProvider\Codex\CodexProvider;
-use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
-use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 if (!defined('ABSPATH')) {
@@ -53,12 +50,7 @@ function register_provider(): void
     }
 
     if (!$registry->hasProvider(CodexProvider::class)) {
-        $tokenStore = new CodexTokenStore();
         $registry->registerProvider(CodexProvider::class);
-        $registry->setProviderRequestAuthentication(
-            CodexProvider::class,
-            new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore))
-        );
     }
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,10 @@ declare(strict_types=1);
 namespace WordPress\OpenAiAiProvider;
 
 use WordPress\AiClient\AiClient;
+use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
+use WordPress\OpenAiAiProvider\Codex\CodexProvider;
+use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
+use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 if (!defined('ABSPATH')) {
@@ -44,11 +48,18 @@ function register_provider(): void
 
     $registry = AiClient::defaultRegistry();
 
-    if ($registry->hasProvider(OpenAiProvider::class)) {
-        return;
+    if (!$registry->hasProvider(OpenAiProvider::class)) {
+        $registry->registerProvider(OpenAiProvider::class);
     }
 
-    $registry->registerProvider(OpenAiProvider::class);
+    if (!$registry->hasProvider(CodexProvider::class)) {
+        $tokenStore = new CodexTokenStore();
+        $registry->registerProvider(CodexProvider::class);
+        $registry->setProviderRequestAuthentication(
+            CodexProvider::class,
+            new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore))
+        );
+    }
 }
 
 add_action('init', __NAMESPACE__ . '\\register_provider', 5);

--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,10 @@ declare(strict_types=1);
 namespace WordPress\OpenAiAiProvider;
 
 use WordPress\AiClient\AiClient;
+use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
 use WordPress\OpenAiAiProvider\Codex\CodexProvider;
+use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
+use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 if (!defined('ABSPATH')) {
@@ -52,6 +55,12 @@ function register_provider(): void
     if (!$registry->hasProvider(CodexProvider::class)) {
         $registry->registerProvider(CodexProvider::class);
     }
+
+    $codexTokenStore = new CodexTokenStore();
+    $registry->setProviderRequestAuthentication(
+        'codex',
+        new CodexRequestAuthentication($codexTokenStore, new CodexOAuthClient($codexTokenStore))
+    );
 }
 
 add_action('init', __NAMESPACE__ . '\\register_provider', 5);

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,7 @@ This plugin provides OpenAI integration for the PHP AI Client SDK. It enables Wo
 
 * Text generation with GPT models
 * Image generation with DALL-E models
+* Optional ChatGPT subscription-backed Codex provider
 * Function calling support
 * Web search support
 * Automatic provider registration
@@ -30,12 +31,14 @@ Available models are dynamically discovered from the OpenAI API, including GPT m
 * For WordPress 6.9, the [wordpress/php-ai-client](https://github.com/WordPress/php-ai-client) package must be installed
 * For WordPress 7.0 and above, no additional changes are required
 * OpenAI API key
+* Optional Codex OAuth refresh token for the Codex provider
 
 == Installation ==
 
 1. Upload the plugin files to `/wp-content/plugins/ai-provider-for-openai/`
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. Configure your OpenAI API key via the `OPENAI_API_KEY` environment variable or constant
+4. Optionally configure Codex OAuth token data with the `ai_provider_openai_codex_oauth_tokens` option or filter
 
 == Frequently Asked Questions ==
 

--- a/src/Codex/CodexModelMetadataDirectory.php
+++ b/src/Codex/CodexModelMetadataDirectory.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
+
+/**
+ * Model metadata directory for ChatGPT Codex models.
+ *
+ * @since n.e.x.t
+ */
+class CodexModelMetadataDirectory implements ModelMetadataDirectoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function listModelMetadata(): array
+    {
+        return array_values($this->getModelMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function hasModelMetadata(string $modelId): bool
+    {
+        return isset($this->getModelMap()[$modelId]);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getModelMetadata(string $modelId): ModelMetadata
+    {
+        $models = $this->getModelMap();
+        if (!isset($models[$modelId])) {
+            throw new InvalidArgumentException('No Codex model with the requested ID was found.');
+        }
+
+        return $models[$modelId];
+    }
+
+    /**
+     * Gets the supported Codex model map.
+     *
+     * @since n.e.x.t
+     *
+     * @return array<string, ModelMetadata> Model metadata keyed by ID.
+     */
+    private function getModelMap(): array
+    {
+        $options = [
+            new SupportedOption(OptionEnum::systemInstruction()),
+            new SupportedOption(OptionEnum::maxTokens()),
+            new SupportedOption(OptionEnum::temperature()),
+            new SupportedOption(OptionEnum::topP()),
+            new SupportedOption(OptionEnum::outputMimeType(), ['text/plain', 'application/json']),
+            new SupportedOption(OptionEnum::outputSchema()),
+            new SupportedOption(OptionEnum::customOptions()),
+            new SupportedOption(OptionEnum::inputModalities(), [[ModalityEnum::text()]]),
+            new SupportedOption(OptionEnum::outputModalities(), [[ModalityEnum::text()]]),
+        ];
+
+        $models = [];
+        foreach (['gpt-5.5', 'gpt-5', 'codex-mini-latest'] as $modelId) {
+            $models[$modelId] = new ModelMetadata(
+                $modelId,
+                $modelId,
+                [CapabilityEnum::textGeneration(), CapabilityEnum::chatHistory()],
+                $options
+            );
+        }
+
+        return $models;
+    }
+}

--- a/src/Codex/CodexOAuthClient.php
+++ b/src/Codex/CodexOAuthClient.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use RuntimeException;
+
+/**
+ * Refreshes ChatGPT/Codex OAuth access tokens.
+ *
+ * @since n.e.x.t
+ */
+class CodexOAuthClient
+{
+    private const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+    private const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+
+    /**
+     * @var CodexTokenStore Token store.
+     */
+    private CodexTokenStore $tokenStore;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param CodexTokenStore $tokenStore Token store.
+     */
+    public function __construct(CodexTokenStore $tokenStore)
+    {
+        $this->tokenStore = $tokenStore;
+    }
+
+    /**
+     * Gets a fresh access token.
+     *
+     * @since n.e.x.t
+     *
+     * @return string Access token.
+     * @throws RuntimeException If OAuth refresh fails.
+     */
+    public function getAccessToken(): string
+    {
+        $accessToken = $this->tokenStore->getAccessToken();
+        if ($accessToken !== null) {
+            return $accessToken;
+        }
+
+        $tokens = $this->tokenStore->getTokens();
+        $refreshToken = $tokens['refresh_token'] ?? '';
+        if ($refreshToken === '') {
+            throw new RuntimeException('Codex OAuth refresh token is not configured.');
+        }
+
+        $data = $this->refreshAccessToken($refreshToken);
+        if (empty($data['access_token']) || !is_scalar($data['access_token'])) {
+            throw new RuntimeException('Codex OAuth refresh returned an invalid response.');
+        }
+
+        $updated = array_merge(
+            $tokens,
+            [
+                'access_token' => (string) $data['access_token'],
+                'expires_at' => time() + $this->getIntegerValue($data['expires_in'] ?? null, 3600),
+            ]
+        );
+
+        if (!empty($data['refresh_token']) && is_scalar($data['refresh_token'])) {
+            $updated['refresh_token'] = (string) $data['refresh_token'];
+        }
+
+        $this->tokenStore->updateTokens($updated);
+        return (string) $data['access_token'];
+    }
+
+    /**
+     * Refreshes an access token.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $refreshToken Refresh token.
+     * @return array<string, mixed> Response data.
+     * @throws RuntimeException If the request fails.
+     */
+    private function refreshAccessToken(string $refreshToken): array
+    {
+        $body = http_build_query(
+            [
+                'grant_type' => 'refresh_token',
+                'client_id' => self::CLIENT_ID,
+                'refresh_token' => $refreshToken,
+            ]
+        );
+
+        $context = stream_context_create(
+            [
+                    'http' => [
+                        'method' => 'POST',
+                        'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+                        'content' => $body,
+                        'ignore_errors' => true,
+                        'timeout' => 20,
+                    ],
+                ]
+        );
+        $responseBody = file_get_contents(self::TOKEN_URL, false, $context);
+        if ($responseBody === false) {
+            throw new RuntimeException('Codex OAuth refresh failed.');
+        }
+
+        $data = json_decode($responseBody, true);
+        if (!is_array($data)) {
+            throw new RuntimeException('Codex OAuth refresh returned an invalid response.');
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
+    }
+
+    /**
+     * Gets an integer value with a fallback.
+     *
+     * @since n.e.x.t
+     *
+     * @param mixed $value Raw value.
+     * @param int $fallback Fallback value.
+     * @return int Integer value.
+     */
+    private function getIntegerValue($value, int $fallback): int
+    {
+        if (!is_numeric($value)) {
+            return $fallback;
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Codex/CodexOAuthClient.php
+++ b/src/Codex/CodexOAuthClient.php
@@ -145,7 +145,10 @@ class CodexOAuthClient
         $isWpError = 'is_wp_error';
         // @phpstan-ignore-next-line WordPress error helper is available at runtime when function_exists() passes.
         if (function_exists('is_wp_error') && $isWpError($response)) {
-            throw new RuntimeException('Codex OAuth refresh failed.');
+            $message = is_object($response) && method_exists($response, 'get_error_message')
+                ? $response->get_error_message()
+                : 'WordPress HTTP API error';
+            throw new RuntimeException('Codex OAuth refresh failed: ' . $this->sanitizeErrorPreview($message));
         }
 
         $wpRemoteRetrieveResponseCode = 'wp_remote_retrieve_response_code';
@@ -155,10 +158,6 @@ class CodexOAuthClient
             $rawStatusCode = $wpRemoteRetrieveResponseCode($response);
         }
         $statusCode = is_numeric($rawStatusCode) ? (int) $rawStatusCode : 0;
-        if ($statusCode < 200 || $statusCode >= 300) {
-            throw new RuntimeException('Codex OAuth refresh failed.');
-        }
-
         $wpRemoteRetrieveBody = 'wp_remote_retrieve_body';
         $rawResponseBody = '';
         if (function_exists('wp_remote_retrieve_body')) {
@@ -166,9 +165,21 @@ class CodexOAuthClient
             $rawResponseBody = $wpRemoteRetrieveBody($response);
         }
         $responseBody = is_scalar($rawResponseBody) ? (string) $rawResponseBody : '';
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException(
+                sprintf(
+                    'Codex OAuth refresh failed with HTTP %d: %s',
+                    $statusCode,
+                    $this->sanitizeErrorPreview($responseBody)
+                )
+            );
+        }
+
         $data = json_decode($responseBody, true);
         if (!is_array($data)) {
-            throw new RuntimeException('Codex OAuth refresh returned an invalid response.');
+            throw new RuntimeException(
+                'Codex OAuth refresh returned an invalid response: ' . $this->sanitizeErrorPreview($responseBody)
+            );
         }
 
         /** @var array<string, mixed> $data */
@@ -191,5 +202,28 @@ class CodexOAuthClient
         }
 
         return (int) $value;
+    }
+
+    /**
+     * Builds a bounded single-line OAuth error preview without exposing token material.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $message Raw error message or body.
+     * @return string Sanitized preview.
+     */
+    private function sanitizeErrorPreview(string $message): string
+    {
+        $message = preg_replace('/\s+/', ' ', $message);
+        $message = is_string($message) ? trim($message) : '';
+        if ($message === '') {
+            return 'empty response';
+        }
+
+        if (strlen($message) > 500) {
+            $message = substr($message, 0, 500) . '...';
+        }
+
+        return $message;
     }
 }

--- a/src/Codex/CodexOAuthClient.php
+++ b/src/Codex/CodexOAuthClient.php
@@ -86,20 +86,22 @@ class CodexOAuthClient
      */
     private function refreshAccessToken(string $refreshToken): array
     {
-        $body = http_build_query(
-            [
-                'grant_type' => 'refresh_token',
-                'client_id' => self::CLIENT_ID,
-                'refresh_token' => $refreshToken,
-            ]
-        );
+        $body = [
+            'grant_type' => 'refresh_token',
+            'client_id' => self::CLIENT_ID,
+            'refresh_token' => $refreshToken,
+        ];
+
+        if (function_exists('wp_remote_post')) {
+            return $this->refreshAccessTokenWithWordPress($body);
+        }
 
         $context = stream_context_create(
             [
                     'http' => [
                         'method' => 'POST',
                         'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
-                        'content' => $body,
+                        'content' => http_build_query($body),
                         'ignore_errors' => true,
                         'timeout' => 20,
                     ],
@@ -110,6 +112,60 @@ class CodexOAuthClient
             throw new RuntimeException('Codex OAuth refresh failed.');
         }
 
+        $data = json_decode($responseBody, true);
+        if (!is_array($data)) {
+            throw new RuntimeException('Codex OAuth refresh returned an invalid response.');
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
+    }
+
+    /**
+     * Refreshes an access token using the WordPress HTTP API.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, string> $body Request body.
+     * @return array<string, mixed> Response data.
+     * @throws RuntimeException If the request fails.
+     */
+    private function refreshAccessTokenWithWordPress(array $body): array
+    {
+        $wpRemotePost = 'wp_remote_post';
+        // @phpstan-ignore-next-line WordPress HTTP API is available at runtime when function_exists() passes.
+        $response = $wpRemotePost(self::TOKEN_URL, [
+            'body' => $body,
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+            'timeout' => 20,
+        ]);
+
+        $isWpError = 'is_wp_error';
+        // @phpstan-ignore-next-line WordPress error helper is available at runtime when function_exists() passes.
+        if (function_exists('is_wp_error') && $isWpError($response)) {
+            throw new RuntimeException('Codex OAuth refresh failed.');
+        }
+
+        $wpRemoteRetrieveResponseCode = 'wp_remote_retrieve_response_code';
+        $rawStatusCode = 0;
+        if (function_exists('wp_remote_retrieve_response_code')) {
+            // @phpstan-ignore-next-line WordPress HTTP helper is available at runtime when function_exists() passes.
+            $rawStatusCode = $wpRemoteRetrieveResponseCode($response);
+        }
+        $statusCode = is_numeric($rawStatusCode) ? (int) $rawStatusCode : 0;
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException('Codex OAuth refresh failed.');
+        }
+
+        $wpRemoteRetrieveBody = 'wp_remote_retrieve_body';
+        $rawResponseBody = '';
+        if (function_exists('wp_remote_retrieve_body')) {
+            // @phpstan-ignore-next-line WordPress HTTP helper is available at runtime when function_exists() passes.
+            $rawResponseBody = $wpRemoteRetrieveBody($response);
+        }
+        $responseBody = is_scalar($rawResponseBody) ? (string) $rawResponseBody : '';
         $data = json_decode($responseBody, true);
         if (!is_array($data)) {
             throw new RuntimeException('Codex OAuth refresh returned an invalid response.');

--- a/src/Codex/CodexOAuthClient.php
+++ b/src/Codex/CodexOAuthClient.php
@@ -145,9 +145,10 @@ class CodexOAuthClient
         $isWpError = 'is_wp_error';
         // @phpstan-ignore-next-line WordPress error helper is available at runtime when function_exists() passes.
         if (function_exists('is_wp_error') && $isWpError($response)) {
-            $message = is_object($response) && method_exists($response, 'get_error_message')
+            $rawMessage = is_object($response) && method_exists($response, 'get_error_message')
                 ? $response->get_error_message()
                 : 'WordPress HTTP API error';
+            $message = is_scalar($rawMessage) ? (string) $rawMessage : 'WordPress HTTP API error';
             throw new RuntimeException('Codex OAuth refresh failed: ' . $this->sanitizeErrorPreview($message));
         }
 

--- a/src/Codex/CodexProvider.php
+++ b/src/Codex/CodexProvider.php
@@ -9,10 +9,8 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
-use WordPress\AiClient\Providers\Contracts\ProviderWithRequestAuthenticationInterface;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
-use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
@@ -22,7 +20,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @since n.e.x.t
  */
-class CodexProvider extends AbstractApiProvider implements ProviderWithRequestAuthenticationInterface
+class CodexProvider extends AbstractApiProvider
 {
     /**
      * {@inheritDoc}
@@ -64,7 +62,7 @@ class CodexProvider extends AbstractApiProvider implements ProviderWithRequestAu
             'ChatGPT Codex',
             ProviderTypeEnum::cloud(),
             'https://chatgpt.com',
-            RequestAuthenticationMethod::apiKey(),
+            RequestAuthenticationMethod::bearerToken(),
         ];
 
         if (version_compare(AiClient::VERSION, '1.2.0', '>=')) {
@@ -86,17 +84,6 @@ class CodexProvider extends AbstractApiProvider implements ProviderWithRequestAu
     protected static function createProviderAvailability(): ProviderAvailabilityInterface
     {
         return new CodexProviderAvailability(new CodexTokenStore());
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @since n.e.x.t
-     */
-    public static function requestAuthentication(): ?RequestAuthenticationInterface
-    {
-        $tokenStore = new CodexTokenStore();
-        return new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore));
     }
 
     /**

--- a/src/Codex/CodexProvider.php
+++ b/src/Codex/CodexProvider.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
+use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+/**
+ * Provider for ChatGPT Codex subscription-backed access.
+ *
+ * @since n.e.x.t
+ */
+class CodexProvider extends AbstractApiProvider
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function baseUrl(): string
+    {
+        return 'https://chatgpt.com/backend-api/codex';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function createModel(
+        ModelMetadata $modelMetadata,
+        ProviderMetadata $providerMetadata
+    ): ModelInterface {
+        foreach ($modelMetadata->getSupportedCapabilities() as $capability) {
+            if ($capability->isTextGeneration()) {
+                return new CodexTextGenerationModel($modelMetadata, $providerMetadata);
+            }
+        }
+
+        throw new RuntimeException('Unsupported Codex model capabilities.');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function createProviderMetadata(): ProviderMetadata
+    {
+        $providerMetadataArgs = [
+            'codex',
+            'ChatGPT Codex',
+            ProviderTypeEnum::cloud(),
+            'https://chatgpt.com',
+            RequestAuthenticationMethod::apiKey(),
+        ];
+
+        if (version_compare(AiClient::VERSION, '1.2.0', '>=')) {
+            if (function_exists('__')) {
+                $providerMetadataArgs[] = __('ChatGPT subscription-backed Codex access.', 'ai-provider-for-openai');
+            } else {
+                $providerMetadataArgs[] = 'ChatGPT subscription-backed Codex access.';
+            }
+        }
+
+        return new ProviderMetadata(...$providerMetadataArgs);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function createProviderAvailability(): ProviderAvailabilityInterface
+    {
+        return new CodexProviderAvailability(new CodexTokenStore());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function createModelMetadataDirectory(): ModelMetadataDirectoryInterface
+    {
+        return new CodexModelMetadataDirectory();
+    }
+}

--- a/src/Codex/CodexProvider.php
+++ b/src/Codex/CodexProvider.php
@@ -62,7 +62,7 @@ class CodexProvider extends AbstractApiProvider
             'ChatGPT Codex',
             ProviderTypeEnum::cloud(),
             'https://chatgpt.com',
-            RequestAuthenticationMethod::bearerToken(),
+            RequestAuthenticationMethod::apiKey(),
         ];
 
         if (version_compare(AiClient::VERSION, '1.2.0', '>=')) {

--- a/src/Codex/CodexProvider.php
+++ b/src/Codex/CodexProvider.php
@@ -9,8 +9,10 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderWithRequestAuthenticationInterface;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
@@ -20,7 +22,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @since n.e.x.t
  */
-class CodexProvider extends AbstractApiProvider
+class CodexProvider extends AbstractApiProvider implements ProviderWithRequestAuthenticationInterface
 {
     /**
      * {@inheritDoc}
@@ -84,6 +86,17 @@ class CodexProvider extends AbstractApiProvider
     protected static function createProviderAvailability(): ProviderAvailabilityInterface
     {
         return new CodexProviderAvailability(new CodexTokenStore());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public static function requestAuthentication(): ?RequestAuthenticationInterface
+    {
+        $tokenStore = new CodexTokenStore();
+        return new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore));
     }
 
     /**

--- a/src/Codex/CodexProviderAvailability.php
+++ b/src/Codex/CodexProviderAvailability.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+
+/**
+ * Availability checker for the Codex provider.
+ *
+ * @since n.e.x.t
+ */
+class CodexProviderAvailability implements ProviderAvailabilityInterface
+{
+    /**
+     * @var CodexTokenStore Token store.
+     */
+    private CodexTokenStore $tokenStore;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param CodexTokenStore $tokenStore Token store.
+     */
+    public function __construct(CodexTokenStore $tokenStore)
+    {
+        $this->tokenStore = $tokenStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function isConfigured(): bool
+    {
+        return $this->tokenStore->hasRefreshToken();
+    }
+}

--- a/src/Codex/CodexRequestAuthentication.php
+++ b/src/Codex/CodexRequestAuthentication.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\OpenAiAiProvider\Codex;
 
-use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
-use WordPress\AiClient\Providers\Http\DTO\BearerTokenRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 
 /**
@@ -13,7 +12,7 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
  *
  * @since n.e.x.t
  */
-class CodexRequestAuthentication extends BearerTokenRequestAuthentication implements RequestAuthenticationInterface
+class CodexRequestAuthentication extends ApiKeyRequestAuthentication
 {
     /**
      * @var CodexTokenStore Token store.

--- a/src/Codex/CodexRequestAuthentication.php
+++ b/src/Codex/CodexRequestAuthentication.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+
+/**
+ * Authenticates requests to the ChatGPT Codex backend.
+ *
+ * Extends API key authentication temporarily so the current client registry accepts it.
+ *
+ * @since n.e.x.t
+ */
+class CodexRequestAuthentication extends ApiKeyRequestAuthentication
+{
+    /**
+     * @var CodexTokenStore Token store.
+     */
+    private CodexTokenStore $tokenStore;
+
+    /**
+     * @var CodexOAuthClient OAuth client.
+     */
+    private CodexOAuthClient $oauthClient;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param CodexTokenStore $tokenStore Token store.
+     * @param CodexOAuthClient $oauthClient OAuth client.
+     */
+    public function __construct(CodexTokenStore $tokenStore, CodexOAuthClient $oauthClient)
+    {
+        parent::__construct('codex-oauth');
+        $this->tokenStore = $tokenStore;
+        $this->oauthClient = $oauthClient;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function authenticateRequest(Request $request): Request
+    {
+        $request = $request->withHeader('Authorization', 'Bearer ' . $this->oauthClient->getAccessToken());
+
+        $accountId = $this->tokenStore->getAccountId();
+        if ($accountId !== null && $accountId !== '') {
+            $request = $request->withHeader('ChatGPT-Account-ID', $accountId);
+        }
+
+        if ($this->tokenStore->isFedramp()) {
+            $request = $request->withHeader('X-OpenAI-Fedramp', 'true');
+        }
+
+        return $request;
+    }
+}

--- a/src/Codex/CodexRequestAuthentication.php
+++ b/src/Codex/CodexRequestAuthentication.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\OpenAiAiProvider\Codex;
 
-use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 
 /**
@@ -14,7 +14,7 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
  *
  * @since n.e.x.t
  */
-class CodexRequestAuthentication extends ApiKeyRequestAuthentication
+class CodexRequestAuthentication implements RequestAuthenticationInterface
 {
     /**
      * @var CodexTokenStore Token store.
@@ -36,7 +36,6 @@ class CodexRequestAuthentication extends ApiKeyRequestAuthentication
      */
     public function __construct(CodexTokenStore $tokenStore, CodexOAuthClient $oauthClient)
     {
-        parent::__construct('codex-oauth');
         $this->tokenStore = $tokenStore;
         $this->oauthClient = $oauthClient;
     }
@@ -60,5 +59,18 @@ class CodexRequestAuthentication extends ApiKeyRequestAuthentication
         }
 
         return $request;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public static function getJsonSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [],
+        ];
     }
 }

--- a/src/Codex/CodexRequestAuthentication.php
+++ b/src/Codex/CodexRequestAuthentication.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace WordPress\OpenAiAiProvider\Codex;
 
 use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\BearerTokenRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 
 /**
  * Authenticates requests to the ChatGPT Codex backend.
  *
- * Extends API key authentication temporarily so the current client registry accepts it.
- *
  * @since n.e.x.t
  */
-class CodexRequestAuthentication implements RequestAuthenticationInterface
+class CodexRequestAuthentication extends BearerTokenRequestAuthentication implements RequestAuthenticationInterface
 {
     /**
      * @var CodexTokenStore Token store.
@@ -36,6 +35,8 @@ class CodexRequestAuthentication implements RequestAuthenticationInterface
      */
     public function __construct(CodexTokenStore $tokenStore, CodexOAuthClient $oauthClient)
     {
+        parent::__construct('');
+
         $this->tokenStore = $tokenStore;
         $this->oauthClient = $oauthClient;
     }

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\Http\Util\ResponseUtil;
+use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
+use WordPress\AiClient\Results\DTO\Candidate;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+
+/**
+ * Text generation model for ChatGPT Codex using the Codex Responses endpoint.
+ *
+ * @since n.e.x.t
+ */
+class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function generateTextResult(array $prompt): GenerativeAiResult
+    {
+        $request = new Request(
+            HttpMethodEnum::POST(),
+            CodexProvider::url('responses'),
+            ['Content-Type' => 'application/json'],
+            $this->prepareGenerateTextParams($prompt),
+            $this->getRequestOptions()
+        );
+
+        $request = $this->getRequestAuthentication()->authenticateRequest($request);
+        $response = $this->getHttpTransporter()->send($request);
+        ResponseUtil::throwIfNotSuccessful($response);
+
+        return $this->parseResponseToResult($response);
+    }
+
+    /**
+     * Prepares the request payload.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt Prompt messages.
+     * @return array<string, mixed> Request payload.
+     */
+    private function prepareGenerateTextParams(array $prompt): array
+    {
+        $config = $this->getConfig();
+        $params = [
+            'model' => $this->metadata()->getId(),
+            'input' => $this->prepareInput($prompt),
+            'instructions' => $config->getSystemInstruction() ?: 'You are a concise coding assistant.',
+            'store' => false,
+            'stream' => true,
+        ];
+
+        $maxTokens = $config->getMaxTokens();
+        if ($maxTokens !== null) {
+            $params['max_output_tokens'] = $maxTokens;
+        }
+
+        $temperature = $config->getTemperature();
+        if ($temperature !== null) {
+            $params['temperature'] = $temperature;
+        }
+
+        $topP = $config->getTopP();
+        if ($topP !== null) {
+            $params['top_p'] = $topP;
+        }
+
+        if ($config->getOutputMimeType() === 'application/json' && $config->getOutputSchema()) {
+            $params['text'] = [
+                'format' => [
+                    'type' => 'json_schema',
+                    'name' => 'response_schema',
+                    'schema' => $config->getOutputSchema(),
+                    'strict' => true,
+                ],
+            ];
+        }
+
+        foreach ($config->getCustomOptions() as $key => $value) {
+            if (isset($params[$key])) {
+                throw new InvalidArgumentException(
+                    sprintf('The custom option "%s" conflicts with an existing Codex request parameter.', $key)
+                );
+            }
+            $params[$key] = $value;
+        }
+
+        return $params;
+    }
+
+    /**
+     * Converts prompt messages to Codex Responses input items.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $messages Prompt messages.
+     * @return list<array<string, mixed>> Input items.
+     */
+    private function prepareInput(array $messages): array
+    {
+        $input = [];
+        foreach ($messages as $message) {
+            $content = [];
+            foreach ($message->getParts() as $part) {
+                if (!$part->getType()->isText()) {
+                    throw new InvalidArgumentException(
+                        'Codex text generation currently supports text message parts only.'
+                    );
+                }
+                $content[] = [
+                    'type' => $message->getRole()->isModel() ? 'output_text' : 'input_text',
+                    'text' => $part->getText(),
+                ];
+            }
+
+            $input[] = [
+                'role' => $this->roleToResponsesRole($message->getRole()),
+                'content' => $content,
+            ];
+        }
+
+        return $input;
+    }
+
+    /**
+     * Converts a client role to a Responses API role.
+     *
+     * @since n.e.x.t
+     *
+     * @param MessageRoleEnum $role Message role.
+     * @return string Responses API role.
+     */
+    private function roleToResponsesRole(MessageRoleEnum $role): string
+    {
+        return $role->isModel() ? 'assistant' : 'user';
+    }
+
+    /**
+     * Parses an API response into a result.
+     *
+     * @since n.e.x.t
+     *
+     * @param Response $response API response.
+     * @return GenerativeAiResult Result.
+     */
+    private function parseResponseToResult(Response $response): GenerativeAiResult
+    {
+        $data = $response->getData();
+        if (!is_array($data)) {
+            $data = $this->parseSseResponse((string) $response->getBody());
+        }
+
+        $text = '';
+        if (isset($data['output_text']) && is_string($data['output_text'])) {
+            $text = $data['output_text'];
+        } elseif (isset($data['output']) && is_array($data['output'])) {
+            /** @var array<int, mixed> $output */
+            $output = $data['output'];
+            $text = $this->extractOutputText($output);
+        }
+
+        if ($text === '') {
+            throw ResponseException::fromMissingData('ChatGPT Codex', 'output_text');
+        }
+
+        $usage = isset($data['usage']) && is_array($data['usage']) ? $data['usage'] : [];
+        $inputTokens = $this->getIntegerValue($usage['input_tokens'] ?? null);
+        $outputTokens = $this->getIntegerValue($usage['output_tokens'] ?? null);
+
+        return new GenerativeAiResult(
+            isset($data['id']) && is_string($data['id']) ? $data['id'] : '',
+            [new Candidate(new ModelMessage([new MessagePart($text)]), FinishReasonEnum::stop())],
+            new TokenUsage(
+                $inputTokens,
+                $outputTokens,
+                $this->getIntegerValue($usage['total_tokens'] ?? null, $inputTokens + $outputTokens)
+            ),
+            $this->providerMetadata(),
+            $this->metadata(),
+            $data
+        );
+    }
+
+    /**
+     * Parses a buffered text/event-stream response body.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $body Response body.
+     * @return array<string, mixed> Parsed response data.
+     */
+    private function parseSseResponse(string $body): array
+    {
+        $text = '';
+        /** @var array<string, mixed> $completed */
+        $completed = [];
+        $eventData = '';
+        $lines = preg_split("/\r\n|\n|\r/", $body);
+
+        if ($lines === false) {
+            $lines = [];
+        }
+
+        foreach ($lines as $line) {
+            if (trim($line) === '') {
+                $this->consumeSseEventData($eventData, $text, $completed);
+                $eventData = '';
+                continue;
+            }
+
+            if (substr($line, 0, 6) === 'data: ') {
+                $eventData .= substr($line, 6);
+            }
+        }
+
+        $this->consumeSseEventData($eventData, $text, $completed);
+
+        if ($text !== '') {
+            $completed['output_text'] = $text;
+        }
+
+        return $completed;
+    }
+
+    /**
+     * Consumes one SSE event data payload.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $eventData Event data.
+     * @param string $text Accumulated text.
+     * @param array<string, mixed> $completed Completed response data.
+     * @return void
+     */
+    private function consumeSseEventData(string $eventData, string &$text, array &$completed): void
+    {
+        if ($eventData === '' || $eventData === '[DONE]') {
+            return;
+        }
+
+        $data = json_decode($eventData, true);
+        if (!is_array($data)) {
+            return;
+        }
+
+        if (isset($data['delta']) && is_string($data['delta'])) {
+            $text .= $data['delta'];
+        }
+
+        if (isset($data['response']) && is_array($data['response']) && ($data['type'] ?? '') === 'response.completed') {
+            /** @var array<string, mixed> $response */
+            $response = $data['response'];
+            $completed = $response;
+        }
+    }
+
+    /**
+     * Extracts output text from Responses API output items.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<int, mixed> $output Output items.
+     * @return string Output text.
+     */
+    private function extractOutputText(array $output): string
+    {
+        $parts = [];
+        foreach ($output as $item) {
+            if (!is_array($item) || ($item['type'] ?? '') !== 'message' || !isset($item['content'])) {
+                continue;
+            }
+            if (!is_array($item['content'])) {
+                continue;
+            }
+
+            foreach ($item['content'] as $content) {
+                if (is_array($content) && ($content['type'] ?? '') === 'output_text' && isset($content['text'])) {
+                    if (is_string($content['text'])) {
+                        $parts[] = $content['text'];
+                    }
+                }
+            }
+        }
+
+        return implode("\n", $parts);
+    }
+
+    /**
+     * Gets an integer value with a fallback.
+     *
+     * @since n.e.x.t
+     *
+     * @param mixed $value Raw value.
+     * @param int $fallback Fallback value.
+     * @return int Integer value.
+     */
+    private function getIntegerValue($value, int $fallback = 0): int
+    {
+        if (!is_numeric($value)) {
+            return $fallback;
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -22,6 +22,7 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\DTO\TokenUsage;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 
 /**
  * Text generation model for ChatGPT Codex using the Codex Responses endpoint.
@@ -280,7 +281,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
      *
      * @since n.e.x.t
      *
-     * @param array<int, mixed> $functionDeclarations Function declarations.
+     * @param list<FunctionDeclaration> $functionDeclarations Function declarations.
      * @return list<array<string, mixed>> Tool declarations.
      */
     private function prepareToolsParam(array $functionDeclarations): array
@@ -338,6 +339,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
                 if (!is_array($outputItem)) {
                     continue;
                 }
+                /** @var array<string, mixed> $outputItem */
                 $candidate = $this->parseOutputItemToCandidate($outputItem, (int) $index);
                 if ($candidate !== null) {
                     $candidates[] = $candidate;
@@ -527,7 +529,8 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             return;
         }
 
-        $type = (string) ($data['type'] ?? '');
+        $rawType = $data['type'] ?? '';
+        $type = is_scalar($rawType) ? (string) $rawType : '';
         if (
             $type === 'response.output_text.delta' &&
             isset($data['delta']) &&
@@ -548,40 +551,10 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             $item = $data['item'] ?? $data['output_item'] ?? null;
             if (is_array($item)) {
                 $index = $this->getIntegerValue($data['output_index'] ?? count($outputItems), count($outputItems));
+                /** @var array<string, mixed> $item */
                 $outputItems[$index] = $item;
             }
         }
-    }
-
-    /**
-     * Extracts output text from Responses API output items.
-     *
-     * @since n.e.x.t
-     *
-     * @param array<int, mixed> $output Output items.
-     * @return string Output text.
-     */
-    private function extractOutputText(array $output): string
-    {
-        $parts = [];
-        foreach ($output as $item) {
-            if (!is_array($item) || ($item['type'] ?? '') !== 'message' || !isset($item['content'])) {
-                continue;
-            }
-            if (!is_array($item['content'])) {
-                continue;
-            }
-
-            foreach ($item['content'] as $content) {
-                if (is_array($content) && ($content['type'] ?? '') === 'output_text' && isset($content['text'])) {
-                    if (is_string($content['text'])) {
-                        $parts[] = $content['text'];
-                    }
-                }
-            }
-        }
-
-        return implode("\n", $parts);
     }
 
     /**

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -11,6 +11,7 @@ use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
 use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Http\Exception\ResponseException;
@@ -28,6 +29,8 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
  */
 class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
+    private const CONNECT_TIMEOUT_FLOOR = 120.0;
+
     /**
      * {@inheritDoc}
      *
@@ -40,7 +43,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             CodexProvider::url('responses'),
             ['Content-Type' => 'application/json'],
             $this->prepareGenerateTextParams($prompt),
-            $this->getRequestOptions()
+            $this->getCodexRequestOptions()
         );
 
         $request = $this->getRequestAuthentication()->authenticateRequest($request);
@@ -48,6 +51,30 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         ResponseUtil::throwIfNotSuccessful($response);
 
         return $this->parseResponseToResult($response);
+    }
+
+    private function getCodexRequestOptions(): RequestOptions
+    {
+        $current = $this->getRequestOptions();
+        $options = new RequestOptions();
+
+        $timeout = $current?->getTimeout();
+        if ($timeout !== null) {
+            $options->setTimeout($timeout);
+        }
+
+        $connectTimeout = $current?->getConnectTimeout();
+        $connectTimeoutFloor = $timeout !== null
+            ? min(self::CONNECT_TIMEOUT_FLOOR, $timeout)
+            : self::CONNECT_TIMEOUT_FLOOR;
+        $options->setConnectTimeout(max($connectTimeout ?? 0.0, $connectTimeoutFloor));
+
+        $maxRedirects = $current?->getMaxRedirects();
+        if ($maxRedirects !== null) {
+            $options->setMaxRedirects($maxRedirects);
+        }
+
+        return $options;
     }
 
     /**

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -29,6 +29,7 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
  */
 class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
+    private const REQUEST_TIMEOUT_FLOOR = 300.0;
     private const CONNECT_TIMEOUT_FLOOR = 120.0;
 
     /**
@@ -59,14 +60,11 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         $options = new RequestOptions();
 
         $timeout = $current?->getTimeout();
-        if ($timeout !== null) {
-            $options->setTimeout($timeout);
-        }
+        $timeout = max($timeout ?? 0.0, self::REQUEST_TIMEOUT_FLOOR);
+        $options->setTimeout($timeout);
 
         $connectTimeout = $current?->getConnectTimeout();
-        $connectTimeoutFloor = $timeout !== null
-            ? min(self::CONNECT_TIMEOUT_FLOOR, $timeout)
-            : self::CONNECT_TIMEOUT_FLOOR;
+        $connectTimeoutFloor = min(self::CONNECT_TIMEOUT_FLOOR, $timeout);
         $options->setConnectTimeout(max($connectTimeout ?? 0.0, $connectTimeoutFloor));
 
         $maxRedirects = $current?->getMaxRedirects();

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -21,6 +21,7 @@ use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\DTO\TokenUsage;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
 
 /**
  * Text generation model for ChatGPT Codex using the Codex Responses endpoint.
@@ -59,15 +60,15 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         $current = $this->getRequestOptions();
         $options = new RequestOptions();
 
-        $timeout = $current?->getTimeout();
+        $timeout = $current ? $current->getTimeout() : null;
         $timeout = max($timeout ?? 0.0, self::REQUEST_TIMEOUT_FLOOR);
         $options->setTimeout($timeout);
 
-        $connectTimeout = $current?->getConnectTimeout();
+        $connectTimeout = $current ? $current->getConnectTimeout() : null;
         $connectTimeoutFloor = min(self::CONNECT_TIMEOUT_FLOOR, $timeout);
         $options->setConnectTimeout(max($connectTimeout ?? 0.0, $connectTimeoutFloor));
 
-        $maxRedirects = $current?->getMaxRedirects();
+        $maxRedirects = $current ? $current->getMaxRedirects() : null;
         if ($maxRedirects !== null) {
             $options->setMaxRedirects($maxRedirects);
         }
@@ -120,6 +121,11 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             ];
         }
 
+        $functionDeclarations = $config->getFunctionDeclarations();
+        if (is_array($functionDeclarations)) {
+            $params['tools'] = $this->prepareToolsParam($functionDeclarations);
+        }
+
         foreach ($config->getCustomOptions() as $key => $value) {
             if (isset($params[$key])) {
                 throw new InvalidArgumentException(
@@ -142,28 +148,154 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
      */
     private function prepareInput(array $messages): array
     {
+        $this->validateMessages($messages);
+
         $input = [];
         foreach ($messages as $message) {
-            $content = [];
-            foreach ($message->getParts() as $part) {
-                if (!$part->getType()->isText()) {
-                    throw new InvalidArgumentException(
-                        'Codex text generation currently supports text message parts only.'
-                    );
-                }
-                $content[] = [
-                    'type' => $message->getRole()->isModel() ? 'output_text' : 'input_text',
-                    'text' => $part->getText(),
-                ];
+            $inputItem = $this->getMessageInputItem($message);
+            if ($inputItem !== null) {
+                $input[] = $inputItem;
             }
-
-            $input[] = [
-                'role' => $this->roleToResponsesRole($message->getRole()),
-                'content' => $content,
-            ];
         }
 
         return $input;
+    }
+
+    /**
+     * Validates Responses API message shape.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $messages Prompt messages.
+     * @return void
+     */
+    private function validateMessages(array $messages): void
+    {
+        foreach ($messages as $message) {
+            $parts = $message->getParts();
+            if (count($parts) <= 1) {
+                continue;
+            }
+
+            foreach ($parts as $part) {
+                $type = $part->getType();
+                if ($type->isFunctionCall() || $type->isFunctionResponse()) {
+                    throw new InvalidArgumentException(
+                        'Function call and function response parts must be the only part in a message for the Codex '
+                        . 'Responses API.'
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Converts a message to a Codex Responses input item.
+     *
+     * @since n.e.x.t
+     *
+     * @param Message $message Prompt message.
+     * @return array<string, mixed>|null Input item, or null for an empty message.
+     */
+    private function getMessageInputItem(Message $message): ?array
+    {
+        $parts = $message->getParts();
+        if (empty($parts)) {
+            return null;
+        }
+
+        $content = [];
+        foreach ($parts as $part) {
+            $partData = $this->getMessagePartData($part, $message->getRole());
+            $partType = $partData['type'] ?? '';
+            if ($partType === 'function_call' || $partType === 'function_call_output') {
+                return $partData;
+            }
+            $content[] = $partData;
+        }
+
+        return [
+            'role' => $this->roleToResponsesRole($message->getRole()),
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * Converts a message part to a Codex Responses input part.
+     *
+     * @since n.e.x.t
+     *
+     * @param MessagePart     $part Message part.
+     * @param MessageRoleEnum $role Message role.
+     * @return array<string, mixed> Input part.
+     */
+    private function getMessagePartData(MessagePart $part, MessageRoleEnum $role): array
+    {
+        $type = $part->getType();
+        if ($type->isText()) {
+            return [
+                'type' => $role->isModel() ? 'output_text' : 'input_text',
+                'text' => $part->getText(),
+            ];
+        }
+
+        if ($type->isFunctionCall()) {
+            $functionCall = $part->getFunctionCall();
+            if (!$functionCall) {
+                throw new InvalidArgumentException(
+                    'The function_call typed message part must contain a function call.'
+                );
+            }
+
+            return [
+                'type' => 'function_call',
+                'call_id' => $functionCall->getId(),
+                'name' => $functionCall->getName(),
+                'arguments' => json_encode($functionCall->getArgs()),
+            ];
+        }
+
+        if ($type->isFunctionResponse()) {
+            $functionResponse = $part->getFunctionResponse();
+            if (!$functionResponse) {
+                throw new InvalidArgumentException(
+                    'The function_response typed message part must contain a function response.'
+                );
+            }
+
+            return [
+                'type' => 'function_call_output',
+                'call_id' => $functionResponse->getId(),
+                'output' => json_encode($functionResponse->getResponse()),
+            ];
+        }
+
+        throw new InvalidArgumentException(
+            'Codex text generation currently supports text and function message parts only.'
+        );
+    }
+
+    /**
+     * Prepares Codex Responses tool declarations.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<int, mixed> $functionDeclarations Function declarations.
+     * @return list<array<string, mixed>> Tool declarations.
+     */
+    private function prepareToolsParam(array $functionDeclarations): array
+    {
+        $tools = [];
+        foreach ($functionDeclarations as $functionDeclaration) {
+            $tools[] = [
+                'type' => 'function',
+                'name' => $functionDeclaration->getName(),
+                'description' => $functionDeclaration->getDescription(),
+                'parameters' => $functionDeclaration->getParameters(),
+            ];
+        }
+
+        return $tools;
     }
 
     /**
@@ -194,17 +326,33 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             $data = $this->parseSseResponse((string) $response->getBody());
         }
 
-        $text = '';
-        if (isset($data['output_text']) && is_string($data['output_text'])) {
-            $text = $data['output_text'];
-        } elseif (isset($data['output']) && is_array($data['output'])) {
-            /** @var array<int, mixed> $output */
-            $output = $data['output'];
-            $text = $this->extractOutputText($output);
+        $candidates = [];
+        if (isset($data['output']) && is_array($data['output'])) {
+            foreach ($data['output'] as $index => $outputItem) {
+                if (!is_array($outputItem)) {
+                    continue;
+                }
+                $candidate = $this->parseOutputItemToCandidate($outputItem, (int) $index);
+                if ($candidate !== null) {
+                    $candidates[] = $candidate;
+                }
+            }
         }
 
-        if ($text === '') {
-            throw ResponseException::fromMissingData('ChatGPT Codex', 'output_text');
+        if (
+            empty($candidates) &&
+            isset($data['output_text']) &&
+            is_string($data['output_text']) &&
+            $data['output_text'] !== ''
+        ) {
+            $candidates[] = new Candidate(
+                new ModelMessage([new MessagePart($data['output_text'])]),
+                FinishReasonEnum::stop()
+            );
+        }
+
+        if (empty($candidates)) {
+            throw ResponseException::fromMissingData('ChatGPT Codex', 'output');
         }
 
         $usage = isset($data['usage']) && is_array($data['usage']) ? $data['usage'] : [];
@@ -213,7 +361,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
 
         return new GenerativeAiResult(
             isset($data['id']) && is_string($data['id']) ? $data['id'] : '',
-            [new Candidate(new ModelMessage([new MessagePart($text)]), FinishReasonEnum::stop())],
+            $candidates,
             new TokenUsage(
                 $inputTokens,
                 $outputTokens,
@@ -223,6 +371,86 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             $this->metadata(),
             $data
         );
+    }
+
+    /**
+     * Parses one Codex Responses output item into a candidate.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $outputItem Output item.
+     * @param int                  $index      Output index.
+     * @return Candidate|null Candidate, or null for unsupported output items.
+     */
+    private function parseOutputItemToCandidate(array $outputItem, int $index): ?Candidate
+    {
+        $type = $outputItem['type'] ?? '';
+        if ($type === 'function_call') {
+            return $this->parseFunctionCallOutputToCandidate($outputItem, $index);
+        }
+
+        if ($type !== 'message') {
+            return null;
+        }
+
+        $parts = [];
+        if (isset($outputItem['content']) && is_array($outputItem['content'])) {
+            foreach ($outputItem['content'] as $content) {
+                if (!is_array($content)) {
+                    continue;
+                }
+                if (
+                    ($content['type'] ?? '') === 'output_text' &&
+                    isset($content['text']) &&
+                    is_string($content['text'])
+                ) {
+                    $parts[] = new MessagePart($content['text']);
+                }
+            }
+        }
+
+        if (empty($parts)) {
+            return null;
+        }
+
+        return new Candidate(new ModelMessage($parts), FinishReasonEnum::stop());
+    }
+
+    /**
+     * Parses one Codex function_call output item into a tool-call candidate.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $outputItem Function call output item.
+     * @param int                  $index      Output index.
+     * @return Candidate Tool-call candidate.
+     */
+    private function parseFunctionCallOutputToCandidate(array $outputItem, int $index): Candidate
+    {
+        if (!isset($outputItem['call_id']) || !is_string($outputItem['call_id'])) {
+            throw ResponseException::fromMissingData('ChatGPT Codex', "output[{$index}].call_id");
+        }
+        if (!isset($outputItem['name']) || !is_string($outputItem['name'])) {
+            throw ResponseException::fromMissingData('ChatGPT Codex', "output[{$index}].name");
+        }
+
+        $args = null;
+        if (isset($outputItem['arguments']) && is_string($outputItem['arguments'])) {
+            $decoded = json_decode($outputItem['arguments'], true);
+            if (is_array($decoded) && count($decoded) > 0) {
+                $args = $decoded;
+            }
+        }
+
+        $part = new MessagePart(
+            new FunctionCall(
+                $outputItem['call_id'],
+                $outputItem['name'],
+                $args
+            )
+        );
+
+        return new Candidate(new ModelMessage([$part]), FinishReasonEnum::toolCalls());
     }
 
     /**

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -50,7 +50,10 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         );
 
         $request = $this->getRequestAuthentication()->authenticateRequest($request);
-        $response = $this->getHttpTransporter()->send($request);
+        $response = $this->shouldUseNativeCodexStreaming()
+            ? $this->sendStreamingCodexRequest($request)
+            : $this->getHttpTransporter()->send($request);
+        $this->throwIfCodexResponseFailed($response);
         ResponseUtil::throwIfNotSuccessful($response);
 
         return $this->parseResponseToResult($response);
@@ -75,6 +78,124 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         }
 
         return $options;
+    }
+
+    /**
+     * Whether Codex should bypass the buffered php-ai-client transport for SSE.
+     *
+     * @since n.e.x.t
+     *
+     * @return bool True when native WordPress/runtime cURL streaming is available.
+     */
+    private function shouldUseNativeCodexStreaming(): bool
+    {
+        return defined('ABSPATH') && function_exists('curl_init');
+    }
+
+    /**
+     * Sends a Codex request with cURL so required SSE responses are consumed incrementally.
+     *
+     * @since n.e.x.t
+     *
+     * @param Request $request Authenticated Codex HTTP request.
+     * @return Response Buffered response containing the SSE frames received.
+     *
+     * @throws ResponseException When the cURL request fails before a Codex response is available.
+     */
+    private function sendStreamingCodexRequest(Request $request): Response
+    {
+        $curl = curl_init($request->getUri());
+        if (!is_resource($curl) && !($curl instanceof \CurlHandle)) {
+            throw new ResponseException('Unable to initialize ChatGPT Codex streaming request.');
+        }
+
+        $body = $request->getBody();
+        $headers = [];
+        foreach ($request->getHeaders() as $name => $values) {
+            foreach ($values as $value) {
+                $headers[] = $name . ': ' . $value;
+            }
+        }
+
+        /** @var array<string, list<string>> $responseHeaders */
+        $responseHeaders = [];
+        $responseBody = '';
+        $receivedDone = false;
+        $options = $request->getOptions() ?: $this->getCodexRequestOptions();
+
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getMethod()->value);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $body === null ? '' : $body);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
+        curl_setopt($curl, CURLOPT_HEADER, false);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
+        curl_setopt(
+            $curl,
+            CURLOPT_WRITEFUNCTION,
+            static function ($curlHandle, string $chunk) use (&$responseBody, &$receivedDone): int {
+                $responseBody .= $chunk;
+                if (strpos($responseBody, 'data: [DONE]') !== false) {
+                    $receivedDone = true;
+                    return 0;
+                }
+
+                return strlen($chunk);
+            }
+        );
+        curl_setopt(
+            $curl,
+            CURLOPT_HEADERFUNCTION,
+            static function ($curlHandle, string $headerLine) use (&$responseHeaders): int {
+                $trimmed = trim($headerLine);
+                if ($trimmed === '') {
+                    return strlen($headerLine);
+                }
+                if (stripos($trimmed, 'HTTP/') === 0) {
+                    $responseHeaders = [];
+                    return strlen($headerLine);
+                }
+
+                $separator = strpos($trimmed, ':');
+                if ($separator === false) {
+                    return strlen($headerLine);
+                }
+
+                $name = substr($trimmed, 0, $separator);
+                $value = trim(substr($trimmed, $separator + 1));
+                if ($name !== '') {
+                    $responseHeaders[$name][] = $value;
+                }
+
+                return strlen($headerLine);
+            }
+        );
+
+        $timeout = $options->getTimeout();
+        if ($timeout !== null) {
+            curl_setopt($curl, CURLOPT_TIMEOUT, (int) ceil($timeout));
+        }
+        $connectTimeout = $options->getConnectTimeout();
+        if ($connectTimeout !== null) {
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, (int) ceil($connectTimeout));
+        }
+
+        $success = curl_exec($curl);
+        $errno = curl_errno($curl);
+        $error = curl_error($curl);
+        $statusCode = (int) curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        curl_close($curl); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated
+
+        if ($success === false && !$receivedDone) {
+            throw new ResponseException(
+                sprintf('ChatGPT Codex streaming request failed: cURL error %d: %s', $errno, $error)
+            );
+        }
+
+        if ($statusCode < 100 || $statusCode >= 600) {
+            throw new ResponseException('ChatGPT Codex streaming request did not return a valid HTTP response.');
+        }
+
+        return new Response($statusCode, $responseHeaders, $responseBody === '' ? null : $responseBody);
     }
 
     /**
@@ -360,6 +481,11 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         }
 
         if (empty($candidates)) {
+            $failureMessage = $this->responseFailureMessage($data);
+            if ($failureMessage !== null) {
+                throw new ResponseException('Unexpected ChatGPT Codex API response: ' . $failureMessage);
+            }
+
             throw ResponseException::fromMissingData('ChatGPT Codex', 'output');
         }
 
@@ -541,7 +667,40 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             $text .= $data['delta'];
         }
 
-        if (isset($data['response']) && is_array($data['response']) && $type === 'response.completed') {
+        if (
+            isset($data['text']) &&
+            is_string($data['text']) &&
+            $data['text'] !== '' &&
+            in_array($type, ['response.output_text.done', 'response.output_text.added'], true)
+        ) {
+            $text .= $data['text'];
+        }
+
+        if (
+            isset($data['part']) &&
+            is_array($data['part']) &&
+            in_array($type, ['response.content_part.done', 'response.content_part.added'], true)
+        ) {
+            $part = $data['part'];
+            if (
+                in_array(($part['type'] ?? ''), ['output_text', 'text'], true) &&
+                isset($part['text']) &&
+                is_string($part['text']) &&
+                $part['text'] !== ''
+            ) {
+                $text .= $part['text'];
+            }
+        }
+
+        if (
+            isset($data['response']) &&
+            is_array($data['response']) &&
+            in_array(
+                $type,
+                ['response.completed', 'response.failed', 'response.incomplete', 'response.cancelled'],
+                true
+            )
+        ) {
             /** @var array<string, mixed> $response */
             $response = $data['response'];
             $completed = $response;
@@ -573,5 +732,137 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         }
 
         return (int) $value;
+    }
+
+    /**
+     * Throws a Codex-specific error that preserves bounded response details.
+     *
+     * @since n.e.x.t
+     *
+     * @param Response $response HTTP response.
+     * @return void
+     *
+     * @throws ResponseException When the HTTP response is not successful.
+     */
+    private function throwIfCodexResponseFailed(Response $response): void
+    {
+        if ($response->isSuccessful()) {
+            return;
+        }
+
+        $message = sprintf('HTTP %d', $response->getStatusCode());
+        $data = $response->getData();
+        if (is_array($data)) {
+            $failureMessage = $this->responseFailureMessage($data);
+            if ($failureMessage !== null) {
+                $message .= ': ' . $failureMessage;
+            }
+        }
+
+        $bodyPreview = $this->responseBodyPreview($response);
+        if ($bodyPreview !== '') {
+            $message .= ': ' . $bodyPreview;
+        }
+
+        throw new ResponseException('Unexpected ChatGPT Codex API response: ' . $message);
+    }
+
+    /**
+     * Builds a bounded single-line response body preview for diagnostics.
+     *
+     * @since n.e.x.t
+     *
+     * @param Response $response HTTP response.
+     * @return string Sanitized body preview, or empty string.
+     */
+    private function responseBodyPreview(Response $response): string
+    {
+        $body = (string) $response->getBody();
+        if ($body === '') {
+            return '';
+        }
+
+        $body = preg_replace('/\s+/', ' ', $body);
+        $body = is_string($body) ? trim($body) : '';
+        if ($body === '') {
+            return '';
+        }
+
+        if (strlen($body) > 500) {
+            $body = substr($body, 0, 500) . '...';
+        }
+
+        return $body;
+    }
+
+    /**
+     * Builds a useful failure message from a terminal Codex Responses payload.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $data Parsed response data.
+     * @return string|null Failure message, or null when the payload is not a failure.
+     */
+    private function responseFailureMessage(array $data): ?string
+    {
+        $error = $this->responseErrorData($data['error'] ?? null);
+        if ($error !== null) {
+            return $error;
+        }
+
+        $error = $this->responseErrorData($data['last_error'] ?? null);
+        if ($error !== null) {
+            return $error;
+        }
+
+        $status = isset($data['status']) && is_scalar($data['status']) ? (string) $data['status'] : '';
+        if (!in_array($status, ['failed', 'incomplete', 'cancelled'], true)) {
+            return null;
+        }
+
+        $details = [];
+        if (isset($data['incomplete_details']) && is_array($data['incomplete_details'])) {
+            foreach (['reason', 'message'] as $field) {
+                if (isset($data['incomplete_details'][$field]) && is_scalar($data['incomplete_details'][$field])) {
+                    $details[] = (string) $data['incomplete_details'][$field];
+                }
+            }
+        }
+
+        return sprintf(
+            'Response finished with status "%s"%s.',
+            $status,
+            empty($details) ? '' : ': ' . implode('; ', $details)
+        );
+    }
+
+    /**
+     * Formats Codex error data without exposing the raw response body.
+     *
+     * @since n.e.x.t
+     *
+     * @param mixed $error Raw error payload.
+     * @return string|null Error message, or null when absent.
+     */
+    private function responseErrorData($error): ?string
+    {
+        if (!is_array($error)) {
+            return null;
+        }
+
+        $message = isset($error['message']) && is_scalar($error['message']) ? (string) $error['message'] : '';
+        $code = isset($error['code']) && is_scalar($error['code']) ? (string) $error['code'] : '';
+        if ($message === '' && $code === '') {
+            return null;
+        }
+
+        if ($message === '') {
+            return sprintf('Codex error "%s".', $code);
+        }
+        if ($code === '') {
+            return $message;
+        }
+
+        return sprintf('%s (%s).', $message, $code);
     }
 }

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -129,6 +129,10 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
         curl_setopt($curl, CURLOPT_HEADER, false);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
+        $caBundlePath = $this->getWordPressCaBundlePath();
+        if ($caBundlePath !== null) {
+            curl_setopt($curl, CURLOPT_CAINFO, $caBundlePath);
+        }
         curl_setopt(
             $curl,
             CURLOPT_WRITEFUNCTION,
@@ -196,6 +200,25 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         }
 
         return new Response($statusCode, $responseHeaders, $responseBody === '' ? null : $responseBody);
+    }
+
+    /**
+     * Gets WordPress' bundled certificate authority file for sandboxed cURL runtimes.
+     *
+     * @since n.e.x.t
+     *
+     * @return string|null CA bundle path when available.
+     */
+    private function getWordPressCaBundlePath(): ?string
+    {
+        if (!defined('ABSPATH')) {
+            return null;
+        }
+
+        $wpIncludes = defined('WPINC') ? WPINC : 'wp-includes';
+        $path = rtrim((string) ABSPATH, '/\\') . '/' . $wpIncludes . '/certificates/ca-bundle.crt';
+
+        return is_readable($path) ? $path : null;
     }
 
     /**

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -262,7 +262,13 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             return;
         }
 
-        if (isset($data['delta']) && is_string($data['delta'])) {
+        if (
+            ($data['type'] ?? '') === 'response.output_text.delta' &&
+            isset($data['delta']) &&
+            is_string($data['delta'])
+        ) {
+            $text .= $data['delta'];
+        } elseif (isset($data['delta']) && is_string($data['delta'])) {
             $text .= $data['delta'];
         }
 

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -321,9 +321,15 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
      */
     private function parseResponseToResult(Response $response): GenerativeAiResult
     {
-        $data = $response->getData();
+        $body = (string) $response->getBody();
+        if (strpos($body, 'data: ') !== false) {
+            $data = $this->parseSseResponse($body);
+        } else {
+            $data = $response->getData();
+        }
+
         if (!is_array($data)) {
-            $data = $this->parseSseResponse((string) $response->getBody());
+            $data = [];
         }
 
         $candidates = [];
@@ -400,9 +406,10 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
                     continue;
                 }
                 if (
-                    ($content['type'] ?? '') === 'output_text' &&
+                    in_array(($content['type'] ?? ''), ['output_text', 'text'], true) &&
                     isset($content['text']) &&
-                    is_string($content['text'])
+                    is_string($content['text']) &&
+                    $content['text'] !== ''
                 ) {
                     $parts[] = new MessagePart($content['text']);
                 }
@@ -466,6 +473,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         $text = '';
         /** @var array<string, mixed> $completed */
         $completed = [];
+        $outputItems = [];
         $eventData = '';
         $lines = preg_split("/\r\n|\n|\r/", $body);
 
@@ -475,7 +483,7 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
 
         foreach ($lines as $line) {
             if (trim($line) === '') {
-                $this->consumeSseEventData($eventData, $text, $completed);
+                $this->consumeSseEventData($eventData, $text, $completed, $outputItems);
                 $eventData = '';
                 continue;
             }
@@ -485,10 +493,13 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             }
         }
 
-        $this->consumeSseEventData($eventData, $text, $completed);
+        $this->consumeSseEventData($eventData, $text, $completed, $outputItems);
 
         if ($text !== '') {
             $completed['output_text'] = $text;
+        }
+        if (!empty($outputItems) && empty($completed['output'])) {
+            $completed['output'] = array_values($outputItems);
         }
 
         return $completed;
@@ -502,9 +513,10 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
      * @param string $eventData Event data.
      * @param string $text Accumulated text.
      * @param array<string, mixed> $completed Completed response data.
+     * @param array<int, array<string, mixed>> $outputItems Accumulated completed output items.
      * @return void
      */
-    private function consumeSseEventData(string $eventData, string &$text, array &$completed): void
+    private function consumeSseEventData(string $eventData, string &$text, array &$completed, array &$outputItems): void
     {
         if ($eventData === '' || $eventData === '[DONE]') {
             return;
@@ -515,20 +527,29 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             return;
         }
 
+        $type = (string) ($data['type'] ?? '');
         if (
-            ($data['type'] ?? '') === 'response.output_text.delta' &&
+            $type === 'response.output_text.delta' &&
             isset($data['delta']) &&
             is_string($data['delta'])
         ) {
             $text .= $data['delta'];
-        } elseif (isset($data['delta']) && is_string($data['delta'])) {
+        } elseif ($type === '' && isset($data['delta']) && is_string($data['delta'])) {
             $text .= $data['delta'];
         }
 
-        if (isset($data['response']) && is_array($data['response']) && ($data['type'] ?? '') === 'response.completed') {
+        if (isset($data['response']) && is_array($data['response']) && $type === 'response.completed') {
             /** @var array<string, mixed> $response */
             $response = $data['response'];
             $completed = $response;
+        }
+
+        if (in_array($type, ['response.output_item.done', 'response.output_item.added'], true)) {
+            $item = $data['item'] ?? $data['output_item'] ?? null;
+            if (is_array($item)) {
+                $index = $this->getIntegerValue($data['output_index'] ?? count($outputItems), count($outputItems));
+                $outputItems[$index] = $item;
+            }
         }
     }
 

--- a/src/Codex/CodexTextGenerationModel.php
+++ b/src/Codex/CodexTextGenerationModel.php
@@ -105,11 +105,11 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
     private function sendStreamingCodexRequest(Request $request): Response
     {
         $curl = curl_init($request->getUri());
-        if (!is_resource($curl) && !($curl instanceof \CurlHandle)) {
+        if ($curl === false) {
             throw new ResponseException('Unable to initialize ChatGPT Codex streaming request.');
         }
 
-        $body = $request->getBody();
+        $body = (string) ($request->getBody() ?? '');
         $headers = [];
         foreach ($request->getHeaders() as $name => $values) {
             foreach ($values as $value) {
@@ -123,14 +123,15 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
         $receivedDone = false;
         $options = $request->getOptions() ?: $this->getCodexRequestOptions();
 
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getMethod()->value);
+        $method = $request->getMethod()->value ?: 'POST';
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $body === null ? '' : $body);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
         curl_setopt($curl, CURLOPT_HEADER, false);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
         $caBundlePath = $this->getWordPressCaBundlePath();
-        if ($caBundlePath !== null) {
+        if ($caBundlePath !== null && $caBundlePath !== '') {
             curl_setopt($curl, CURLOPT_CAINFO, $caBundlePath);
         }
         curl_setopt(
@@ -199,7 +200,14 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             throw new ResponseException('ChatGPT Codex streaming request did not return a valid HTTP response.');
         }
 
-        return new Response($statusCode, $responseHeaders, $responseBody === '' ? null : $responseBody);
+        $headers = [];
+        foreach ($responseHeaders as $name => $values) {
+            if (is_string($name)) {
+                $headers[$name] = $values;
+            }
+        }
+
+        return new Response($statusCode, $headers, $responseBody === '' ? null : $responseBody);
     }
 
     /**
@@ -215,8 +223,11 @@ class CodexTextGenerationModel extends AbstractApiBasedModel implements TextGene
             return null;
         }
 
-        $wpIncludes = defined('WPINC') ? WPINC : 'wp-includes';
-        $path = rtrim((string) ABSPATH, '/\\') . '/' . $wpIncludes . '/certificates/ca-bundle.crt';
+        $rawAbspath = constant('ABSPATH');
+        $rawWpIncludes = defined('WPINC') ? constant('WPINC') : 'wp-includes';
+        $abspath = is_scalar($rawAbspath) ? (string) $rawAbspath : '';
+        $wpIncludes = is_scalar($rawWpIncludes) ? (string) $rawWpIncludes : 'wp-includes';
+        $path = rtrim($abspath, '/\\') . '/' . $wpIncludes . '/certificates/ca-bundle.crt';
 
         return is_readable($path) ? $path : null;
     }

--- a/src/Codex/CodexTokenStore.php
+++ b/src/Codex/CodexTokenStore.php
@@ -41,7 +41,8 @@ class CodexTokenStore
 
         /** @var array<string, mixed> $tokenData */
         $tokenData = $tokens;
-        $tokens = $this->addConstantTokens($tokenData);
+        $tokens = $this->addEnvironmentTokens($tokenData);
+        $tokens = $this->addConstantTokens($tokens);
 
         if (function_exists('apply_filters')) {
             /**
@@ -139,6 +140,26 @@ class CodexTokenStore
     }
 
     /**
+     * Adds token data from environment variables when present.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $tokens Token data.
+     * @return array<string, mixed> Token data.
+     */
+    private function addEnvironmentTokens(array $tokens): array
+    {
+        foreach ($this->tokenSourceMap() as $name => $tokenKey) {
+            $value = getenv($name);
+            if ($value !== false) {
+                $tokens[$tokenKey] = $value;
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
      * Adds token data from constants when present.
      *
      * @since n.e.x.t
@@ -148,21 +169,31 @@ class CodexTokenStore
      */
     private function addConstantTokens(array $tokens): array
     {
-        $constantMap = [
-            'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN' => 'access_token',
-            'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN' => 'refresh_token',
-            'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT' => 'expires_at',
-            'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID' => 'account_id',
-            'AI_PROVIDER_OPENAI_CODEX_FEDRAMP' => 'fedramp',
-        ];
-
-        foreach ($constantMap as $constantName => $tokenKey) {
+        foreach ($this->tokenSourceMap() as $constantName => $tokenKey) {
             if (defined($constantName)) {
                 $tokens[$tokenKey] = constant($constantName);
             }
         }
 
         return $tokens;
+    }
+
+    /**
+     * Maps environment/constant names to token keys.
+     *
+     * @since n.e.x.t
+     *
+     * @return array<string, string>
+     */
+    private function tokenSourceMap(): array
+    {
+        return [
+            'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN' => 'access_token',
+            'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN' => 'refresh_token',
+            'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT' => 'expires_at',
+            'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID' => 'account_id',
+            'AI_PROVIDER_OPENAI_CODEX_FEDRAMP' => 'fedramp',
+        ];
     }
 
     /**

--- a/src/Codex/CodexTokenStore.php
+++ b/src/Codex/CodexTokenStore.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Codex;
+
+/**
+ * Stores ChatGPT/Codex OAuth tokens.
+ *
+ * @since n.e.x.t
+ *
+ * @phpstan-type CodexTokens array{
+ *     access_token?: string,
+ *     refresh_token?: string,
+ *     expires_at?: int,
+ *     account_id?: string,
+ *     fedramp?: bool
+ * }
+ */
+class CodexTokenStore
+{
+    private const OPTION_NAME = 'ai_provider_openai_codex_oauth_tokens';
+
+    /**
+     * Gets stored token data.
+     *
+     * @since n.e.x.t
+     *
+     * @return CodexTokens Token data.
+     */
+    public function getTokens(): array
+    {
+        $tokens = [];
+        if (function_exists('get_option')) {
+            $tokens = get_option(self::OPTION_NAME, []);
+        }
+
+        if (!is_array($tokens)) {
+            $tokens = [];
+        }
+
+        /** @var array<string, mixed> $tokenData */
+        $tokenData = $tokens;
+        $tokens = $this->addConstantTokens($tokenData);
+
+        if (function_exists('apply_filters')) {
+            /**
+             * Filters the Codex OAuth tokens used by the OpenAI provider.
+             *
+             * @since n.e.x.t
+             *
+             * @param array<string, mixed> $tokens Token data.
+             */
+            $tokens = apply_filters('ai_provider_openai_codex_oauth_tokens', $tokens);
+        }
+
+        if (!is_array($tokens)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $tokens */
+        return $this->sanitizeTokens($tokens);
+    }
+
+    /**
+     * Updates stored token data.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $tokens Token data.
+     * @return void
+     */
+    public function updateTokens(array $tokens): void
+    {
+        if (!function_exists('update_option')) {
+            return;
+        }
+
+        update_option(self::OPTION_NAME, $this->sanitizeTokens($tokens), false);
+    }
+
+    /**
+     * Checks whether a refresh token is configured.
+     *
+     * @since n.e.x.t
+     *
+     * @return bool True if configured.
+     */
+    public function hasRefreshToken(): bool
+    {
+        $tokens = $this->getTokens();
+        return !empty($tokens['refresh_token']);
+    }
+
+    /**
+     * Gets a non-expired access token if available.
+     *
+     * @since n.e.x.t
+     *
+     * @return string|null Access token, or null if unavailable or expired.
+     */
+    public function getAccessToken(): ?string
+    {
+        $tokens = $this->getTokens();
+        $accessToken = $tokens['access_token'] ?? '';
+        $expiresAt = $tokens['expires_at'] ?? 0;
+
+        if ($accessToken === '' || $expiresAt <= time() + 60) {
+            return null;
+        }
+
+        return $accessToken;
+    }
+
+    /**
+     * Gets the ChatGPT account ID if available.
+     *
+     * @since n.e.x.t
+     *
+     * @return string|null Account ID, or null if unavailable.
+     */
+    public function getAccountId(): ?string
+    {
+        $tokens = $this->getTokens();
+        return $tokens['account_id'] ?? null;
+    }
+
+    /**
+     * Checks whether the account uses FedRAMP headers.
+     *
+     * @since n.e.x.t
+     *
+     * @return bool True if FedRAMP mode is enabled.
+     */
+    public function isFedramp(): bool
+    {
+        $tokens = $this->getTokens();
+        return true === ($tokens['fedramp'] ?? false);
+    }
+
+    /**
+     * Adds token data from constants when present.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $tokens Token data.
+     * @return array<string, mixed> Token data.
+     */
+    private function addConstantTokens(array $tokens): array
+    {
+        $constantMap = [
+            'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN' => 'access_token',
+            'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN' => 'refresh_token',
+            'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT' => 'expires_at',
+            'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID' => 'account_id',
+            'AI_PROVIDER_OPENAI_CODEX_FEDRAMP' => 'fedramp',
+        ];
+
+        foreach ($constantMap as $constantName => $tokenKey) {
+            if (defined($constantName)) {
+                $tokens[$tokenKey] = constant($constantName);
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Sanitizes token data.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $tokens Raw token data.
+     * @return CodexTokens Sanitized token data.
+     */
+    private function sanitizeTokens(array $tokens): array
+    {
+        /** @var CodexTokens $sanitized */
+        $sanitized = [];
+        foreach (['access_token', 'refresh_token', 'account_id'] as $key) {
+            if (isset($tokens[$key]) && is_scalar($tokens[$key])) {
+                $sanitized[$key] = trim((string) $tokens[$key]);
+            }
+        }
+
+        if (isset($tokens['expires_at']) && is_numeric($tokens['expires_at'])) {
+            $sanitized['expires_at'] = (int) $tokens['expires_at'];
+        }
+
+        if (isset($tokens['fedramp'])) {
+            $sanitized['fedramp'] = filter_var($tokens['fedramp'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $sanitized;
+    }
+}

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -14,9 +14,77 @@ use WordPress\OpenAiAiProvider\Codex\CodexProvider;
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/src/autoload.php';
 
-define('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN', 'test-access-token');
-define('AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT', time() + 3600);
-define('AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID', 'test-account-id');
+$codexSmokeTokens = [
+    'access_token' => 'expired-access-token',
+    'refresh_token' => 'test-refresh-token',
+    'expires_at' => time() - 3600,
+    'account_id' => 'test-account-id',
+    'fedramp' => true,
+];
+$codexSmokeRefreshCalls = 0;
+$codexSmokeUpdatedTokens = null;
+$codexSmokeAutoload = null;
+
+function get_option(string $option, $default = false)
+{
+    global $codexSmokeTokens;
+
+    if ($option !== 'ai_provider_openai_codex_oauth_tokens') {
+        return $default;
+    }
+
+    return $codexSmokeTokens;
+}
+
+function update_option(string $option, $value, $autoload = null): bool
+{
+    global $codexSmokeAutoload, $codexSmokeTokens, $codexSmokeUpdatedTokens;
+
+    assert($option === 'ai_provider_openai_codex_oauth_tokens');
+    $codexSmokeTokens = $value;
+    $codexSmokeUpdatedTokens = $value;
+    $codexSmokeAutoload = $autoload;
+
+    return true;
+}
+
+function wp_remote_post(string $url, array $args = [])
+{
+    global $codexSmokeRefreshCalls;
+
+    ++$codexSmokeRefreshCalls;
+
+    assert($url === 'https://auth.openai.com/oauth/token');
+    assert(($args['body']['grant_type'] ?? null) === 'refresh_token');
+    assert(($args['body']['client_id'] ?? null) === 'app_EMoamEEZ73f0CkXaXp7hrann');
+    assert(($args['body']['refresh_token'] ?? null) === 'test-refresh-token');
+
+    return [
+        'response' => ['code' => 200],
+        'body' => json_encode(
+            [
+                'access_token' => 'fresh-access-token',
+                'refresh_token' => 'fresh-refresh-token',
+                'expires_in' => 3600,
+            ]
+        ),
+    ];
+}
+
+function wp_remote_retrieve_response_code($response): int
+{
+    return (int) ($response['response']['code'] ?? 0);
+}
+
+function wp_remote_retrieve_body($response): string
+{
+    return (string) ($response['body'] ?? '');
+}
+
+function is_wp_error($response): bool
+{
+    return false;
+}
 
 $registry = new ProviderRegistry();
 $registry->setHttpTransporter(
@@ -24,8 +92,9 @@ $registry->setHttpTransporter(
         public function send(Request $request, ?RequestOptions $options = null): Response
         {
             assert($request->getUri() === 'https://chatgpt.com/backend-api/codex/responses');
-            assert($request->getHeaderAsString('Authorization') === 'Bearer test-access-token');
+            assert($request->getHeaderAsString('Authorization') === 'Bearer fresh-access-token');
             assert($request->getHeaderAsString('ChatGPT-Account-ID') === 'test-account-id');
+            assert($request->getHeaderAsString('X-OpenAI-Fedramp') === 'true');
 
             $data = $request->getData();
             assert(is_array($data));
@@ -37,7 +106,7 @@ $registry->setHttpTransporter(
             $body = implode(
                 "\n\n",
                 [
-                    'data: {"delta":"codex "}',
+                    'data: {"type":"response.output_text.delta","delta":"codex "}',
                     'data: {"delta":"smoke"}',
                     'data: {"type":"response.completed","response":{"id":"resp_test","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
                     'data: [DONE]',
@@ -51,9 +120,16 @@ $registry->setHttpTransporter(
 
 $registry->registerProvider(CodexProvider::class);
 
+assert($registry->isProviderConfigured('codex') === true);
+
 $model = $registry->getProviderModel('codex', 'gpt-5.5');
 $result = $model->generateTextResult([new UserMessage([new MessagePart('hello')])]);
 
 assert($result->toText() === 'codex smoke');
+assert($codexSmokeRefreshCalls === 1);
+assert(is_array($codexSmokeUpdatedTokens));
+assert(($codexSmokeUpdatedTokens['access_token'] ?? null) === 'fresh-access-token');
+assert(($codexSmokeUpdatedTokens['refresh_token'] ?? null) === 'fresh-refresh-token');
+assert($codexSmokeAutoload === false);
 
 echo "Codex smoke passed.\n";

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -126,6 +126,45 @@ $registry->setHttpTransporter(
             assert(($data['stream'] ?? null) === true);
             assert(isset($data['instructions']) && is_string($data['instructions']));
 
+            $inputText = '';
+            foreach (($data['input'] ?? []) as $inputItem) {
+                foreach (($inputItem['content'] ?? []) as $contentItem) {
+                    if (is_array($contentItem) && isset($contentItem['text']) && is_string($contentItem['text'])) {
+                        $inputText .= $contentItem['text'];
+                    }
+                }
+            }
+
+            if (strpos($inputText, 'completed text item') !== false) {
+                $body = implode(
+                    "\n\n",
+                    [
+                        'data: ' . json_encode(
+                            [
+                                'type' => 'response.completed',
+                                'response' => [
+                                    'id' => 'resp_text_item',
+                                    'output' => [
+                                        [
+                                            'type' => 'message',
+                                            'content' => [
+                                                [
+                                                    'type' => 'text',
+                                                    'text' => 'completed text normalized',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ]
+                        ),
+                        'data: [DONE]',
+                    ]
+                );
+
+                return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+            }
+
             if (isset($data['tools'])) {
                 assert(is_array($data['tools']));
                 assert(($data['tools'][0]['type'] ?? null) === 'function');
@@ -151,13 +190,22 @@ $registry->setHttpTransporter(
                     ],
                 ];
 
-                $body = implode(
-                    "\n\n",
-                    [
-                        'data: ' . json_encode(['type' => 'response.completed', 'response' => $response]),
-                        'data: [DONE]',
-                    ]
-                );
+                $body = strpos($inputText, 'streamed tool item') !== false
+                    ? implode(
+                        "\n\n",
+                        [
+                            'data: ' . json_encode(['type' => 'response.output_item.done', 'output_index' => 0, 'item' => $response['output'][0]]),
+                            'data: ' . json_encode(['type' => 'response.completed', 'response' => ['id' => 'resp_tool_streamed']]),
+                            'data: [DONE]',
+                        ]
+                    )
+                    : implode(
+                        "\n\n",
+                        [
+                            'data: ' . json_encode(['type' => 'response.completed', 'response' => $response]),
+                            'data: [DONE]',
+                        ]
+                    );
 
                 return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
             }
@@ -233,6 +281,20 @@ assert($toolCall->getArgs() === ['path' => 'README.md']);
 assert($toolCandidate->getFinishReason()->isToolCalls());
 
 echo "Codex tool call smoke passed.\n";
+
+$textItemResult = $model->generateTextResult([new UserMessage([new MessagePart('completed text item')])]);
+assert($textItemResult->toText() === 'completed text normalized');
+
+echo "Codex completed text item smoke passed.\n";
+
+$streamedToolResult = $model->generateTextResult([new UserMessage([new MessagePart('streamed tool item')])]);
+$streamedToolCall = $streamedToolResult->getCandidates()[0]->getMessage()->getParts()[0]->getFunctionCall();
+assert($streamedToolCall !== null);
+assert($streamedToolCall->getId() === 'call_read');
+assert($streamedToolCall->getName() === 'workspace_read');
+assert($streamedToolCall->getArgs() === ['path' => 'README.md']);
+
+echo "Codex streamed tool item smoke passed.\n";
 
 $model->setConfig(new ModelConfig());
 

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -8,7 +8,9 @@ use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\OpenAiAiProvider\Codex\CodexProvider;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
@@ -98,8 +100,20 @@ $registry->setHttpTransporter(
             $requestOptions = $request->getOptions();
 
             assert($request->getUri() === 'https://chatgpt.com/backend-api/codex/responses');
-            assert(in_array($request->getHeaderAsString('Authorization'), ['Bearer fresh-access-token', 'Bearer env-access-token'], true));
-            assert(in_array($request->getHeaderAsString('ChatGPT-Account-ID'), ['test-account-id', 'env-account-id'], true));
+            assert(
+                in_array(
+                    $request->getHeaderAsString('Authorization'),
+                    ['Bearer fresh-access-token', 'Bearer env-access-token'],
+                    true
+                )
+            );
+            assert(
+                in_array(
+                    $request->getHeaderAsString('ChatGPT-Account-ID'),
+                    ['test-account-id', 'env-account-id'],
+                    true
+                )
+            );
             assert($request->getHeaderAsString('X-OpenAI-Fedramp') === 'true');
             assert($requestOptions instanceof RequestOptions);
             $codexSmokeRequestTimeouts[] = $requestOptions->getTimeout();
@@ -112,12 +126,60 @@ $registry->setHttpTransporter(
             assert(($data['stream'] ?? null) === true);
             assert(isset($data['instructions']) && is_string($data['instructions']));
 
+            if (isset($data['tools'])) {
+                assert(is_array($data['tools']));
+                assert(($data['tools'][0]['type'] ?? null) === 'function');
+                assert(($data['tools'][0]['name'] ?? null) === 'workspace_read');
+                assert(
+                    ($data['tools'][0]['parameters']['properties']['path']['type'] ?? null) === 'string'
+                );
+
+                $response = [
+                    'id' => 'resp_tool',
+                    'output' => [
+                        [
+                            'type' => 'function_call',
+                            'call_id' => 'call_read',
+                            'name' => 'workspace_read',
+                            'arguments' => '{"path":"README.md"}',
+                        ],
+                    ],
+                    'usage' => [
+                        'input_tokens' => 4,
+                        'output_tokens' => 5,
+                        'total_tokens' => 9,
+                    ],
+                ];
+
+                $body = implode(
+                    "\n\n",
+                    [
+                        'data: ' . json_encode(['type' => 'response.completed', 'response' => $response]),
+                        'data: [DONE]',
+                    ]
+                );
+
+                return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+            }
+
             $body = implode(
                 "\n\n",
                 [
                     'data: {"type":"response.output_text.delta","delta":"codex "}',
                     'data: {"delta":"smoke"}',
-                    'data: {"type":"response.completed","response":{"id":"resp_test","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+                    'data: ' . json_encode(
+                        [
+                            'type' => 'response.completed',
+                            'response' => [
+                                'id' => 'resp_test',
+                                'usage' => [
+                                    'input_tokens' => 1,
+                                    'output_tokens' => 2,
+                                    'total_tokens' => 3,
+                                ],
+                            ],
+                        ]
+                    ),
                     'data: [DONE]',
                 ]
             );
@@ -144,6 +206,35 @@ assert(($codexSmokeUpdatedTokens['refresh_token'] ?? null) === 'fresh-refresh-to
 assert($codexSmokeAutoload === false);
 
 echo "Codex smoke passed.\n";
+
+$toolConfig = new ModelConfig();
+$toolConfig->setFunctionDeclarations([
+    new FunctionDeclaration(
+        'workspace_read',
+        'Read a workspace file.',
+        [
+            'type' => 'object',
+            'properties' => [
+                'path' => ['type' => 'string'],
+            ],
+            'required' => ['path'],
+        ]
+    ),
+]);
+$model->setConfig($toolConfig);
+$toolResult = $model->generateTextResult([new UserMessage([new MessagePart('read README')])]);
+$toolCandidate = $toolResult->getCandidates()[0];
+$toolCall = $toolCandidate->getMessage()->getParts()[0]->getFunctionCall();
+
+assert($toolCall !== null);
+assert($toolCall->getId() === 'call_read');
+assert($toolCall->getName() === 'workspace_read');
+assert($toolCall->getArgs() === ['path' => 'README.md']);
+assert($toolCandidate->getFinishReason()->isToolCalls());
+
+echo "Codex tool call smoke passed.\n";
+
+$model->setConfig(new ModelConfig());
 
 $codexSmokeTokens = [];
 putenv('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN=env-access-token');

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -11,7 +11,10 @@ use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
 use WordPress\OpenAiAiProvider\Codex\CodexProvider;
+use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
+use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/src/autoload.php';
@@ -238,6 +241,11 @@ $registry->setHttpTransporter(
 );
 
 $registry->registerProvider(CodexProvider::class);
+$codexTokenStore = new CodexTokenStore();
+$registry->setProviderRequestAuthentication(
+    'codex',
+    new CodexRequestAuthentication($codexTokenStore, new CodexOAuthClient($codexTokenStore))
+);
 
 assert($registry->isProviderConfigured('codex') === true);
 

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
+use WordPress\OpenAiAiProvider\Codex\CodexProvider;
+use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
+use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/src/autoload.php';
+
+define('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN', 'test-access-token');
+define('AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT', time() + 3600);
+define('AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID', 'test-account-id');
+
+$registry = new ProviderRegistry();
+$registry->setHttpTransporter(
+    new class implements HttpTransporterInterface {
+        public function send(Request $request, ?RequestOptions $options = null): Response
+        {
+            assert($request->getUri() === 'https://chatgpt.com/backend-api/codex/responses');
+            assert($request->getHeaderAsString('Authorization') === 'Bearer test-access-token');
+            assert($request->getHeaderAsString('ChatGPT-Account-ID') === 'test-account-id');
+
+            $data = $request->getData();
+            assert(is_array($data));
+            assert(($data['model'] ?? null) === 'gpt-5.5');
+            assert(($data['store'] ?? null) === false);
+            assert(($data['stream'] ?? null) === true);
+            assert(isset($data['instructions']) && is_string($data['instructions']));
+
+            $body = implode(
+                "\n\n",
+                [
+                    'data: {"delta":"codex "}',
+                    'data: {"delta":"smoke"}',
+                    'data: {"type":"response.completed","response":{"id":"resp_test","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+                    'data: [DONE]',
+                ]
+            );
+
+            return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+        }
+    }
+);
+
+$tokenStore = new CodexTokenStore();
+$registry->registerProvider(CodexProvider::class);
+$registry->setProviderRequestAuthentication(
+    CodexProvider::class,
+    new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore))
+);
+
+$model = $registry->getProviderModel('codex', 'gpt-5.5');
+$result = $model->generateTextResult([new UserMessage([new MessagePart('hello')])]);
+
+assert($result->toText() === 'codex smoke');
+
+echo "Codex smoke passed.\n";

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -24,6 +24,7 @@ $codexSmokeTokens = [
 $codexSmokeRefreshCalls = 0;
 $codexSmokeUpdatedTokens = null;
 $codexSmokeAutoload = null;
+$codexSmokeRequestConnectTimeouts = [];
 
 function get_option(string $option, $default = false)
 {
@@ -91,10 +92,16 @@ $registry->setHttpTransporter(
     new class implements HttpTransporterInterface {
         public function send(Request $request, ?RequestOptions $options = null): Response
         {
+            global $codexSmokeRequestConnectTimeouts;
+
+            $requestOptions = $request->getOptions();
+
             assert($request->getUri() === 'https://chatgpt.com/backend-api/codex/responses');
-            assert($request->getHeaderAsString('Authorization') === 'Bearer fresh-access-token');
-            assert($request->getHeaderAsString('ChatGPT-Account-ID') === 'test-account-id');
+            assert(in_array($request->getHeaderAsString('Authorization'), ['Bearer fresh-access-token', 'Bearer env-access-token'], true));
+            assert(in_array($request->getHeaderAsString('ChatGPT-Account-ID'), ['test-account-id', 'env-account-id'], true));
             assert($request->getHeaderAsString('X-OpenAI-Fedramp') === 'true');
+            assert($requestOptions instanceof RequestOptions);
+            $codexSmokeRequestConnectTimeouts[] = $requestOptions->getConnectTimeout();
 
             $data = $request->getData();
             assert(is_array($data));
@@ -126,6 +133,7 @@ $model = $registry->getProviderModel('codex', 'gpt-5.5');
 $result = $model->generateTextResult([new UserMessage([new MessagePart('hello')])]);
 
 assert($result->toText() === 'codex smoke');
+assert($codexSmokeRequestConnectTimeouts[0] === 120.0);
 assert($codexSmokeRefreshCalls === 1);
 assert(is_array($codexSmokeUpdatedTokens));
 assert(($codexSmokeUpdatedTokens['access_token'] ?? null) === 'fresh-access-token');
@@ -150,3 +158,14 @@ assert(($envTokens['account_id'] ?? null) === 'env-account-id');
 assert(($envTokens['fedramp'] ?? null) === true);
 
 echo "Codex env token smoke passed.\n";
+
+$shortOptions = new RequestOptions();
+$shortOptions->setTimeout(60.0);
+$shortOptions->setConnectTimeout(15.0);
+$model->setRequestOptions($shortOptions);
+$result = $model->generateTextResult([new UserMessage([new MessagePart('hello again')])]);
+
+assert($result->toText() === 'codex smoke');
+assert($codexSmokeRequestConnectTimeouts[1] === 60.0);
+
+echo "Codex request timeout floor smoke passed.\n";

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -133,3 +133,20 @@ assert(($codexSmokeUpdatedTokens['refresh_token'] ?? null) === 'fresh-refresh-to
 assert($codexSmokeAutoload === false);
 
 echo "Codex smoke passed.\n";
+
+$codexSmokeTokens = [];
+putenv('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN=env-access-token');
+putenv('AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN=env-refresh-token');
+putenv('AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT=' . (time() + 3600));
+putenv('AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID=env-account-id');
+putenv('AI_PROVIDER_OPENAI_CODEX_FEDRAMP=true');
+
+$envTokenStore = new WordPress\OpenAiAiProvider\Codex\CodexTokenStore();
+$envTokens = $envTokenStore->getTokens();
+
+assert(($envTokens['access_token'] ?? null) === 'env-access-token');
+assert(($envTokens['refresh_token'] ?? null) === 'env-refresh-token');
+assert(($envTokens['account_id'] ?? null) === 'env-account-id');
+assert(($envTokens['fedramp'] ?? null) === true);
+
+echo "Codex env token smoke passed.\n";

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -24,6 +24,7 @@ $codexSmokeTokens = [
 $codexSmokeRefreshCalls = 0;
 $codexSmokeUpdatedTokens = null;
 $codexSmokeAutoload = null;
+$codexSmokeRequestTimeouts = [];
 $codexSmokeRequestConnectTimeouts = [];
 
 function get_option(string $option, $default = false)
@@ -92,7 +93,7 @@ $registry->setHttpTransporter(
     new class implements HttpTransporterInterface {
         public function send(Request $request, ?RequestOptions $options = null): Response
         {
-            global $codexSmokeRequestConnectTimeouts;
+            global $codexSmokeRequestConnectTimeouts, $codexSmokeRequestTimeouts;
 
             $requestOptions = $request->getOptions();
 
@@ -101,6 +102,7 @@ $registry->setHttpTransporter(
             assert(in_array($request->getHeaderAsString('ChatGPT-Account-ID'), ['test-account-id', 'env-account-id'], true));
             assert($request->getHeaderAsString('X-OpenAI-Fedramp') === 'true');
             assert($requestOptions instanceof RequestOptions);
+            $codexSmokeRequestTimeouts[] = $requestOptions->getTimeout();
             $codexSmokeRequestConnectTimeouts[] = $requestOptions->getConnectTimeout();
 
             $data = $request->getData();
@@ -133,6 +135,7 @@ $model = $registry->getProviderModel('codex', 'gpt-5.5');
 $result = $model->generateTextResult([new UserMessage([new MessagePart('hello')])]);
 
 assert($result->toText() === 'codex smoke');
+assert($codexSmokeRequestTimeouts[0] === 300.0);
 assert($codexSmokeRequestConnectTimeouts[0] === 120.0);
 assert($codexSmokeRefreshCalls === 1);
 assert(is_array($codexSmokeUpdatedTokens));
@@ -160,12 +163,13 @@ assert(($envTokens['fedramp'] ?? null) === true);
 echo "Codex env token smoke passed.\n";
 
 $shortOptions = new RequestOptions();
-$shortOptions->setTimeout(60.0);
+$shortOptions->setTimeout(15.0);
 $shortOptions->setConnectTimeout(15.0);
 $model->setRequestOptions($shortOptions);
 $result = $model->generateTextResult([new UserMessage([new MessagePart('hello again')])]);
 
 assert($result->toText() === 'codex smoke');
-assert($codexSmokeRequestConnectTimeouts[1] === 60.0);
+assert($codexSmokeRequestTimeouts[1] === 300.0);
+assert($codexSmokeRequestConnectTimeouts[1] === 120.0);
 
 echo "Codex request timeout floor smoke passed.\n";

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -8,6 +8,7 @@ use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
@@ -168,6 +169,81 @@ $registry->setHttpTransporter(
                 return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
             }
 
+            if (strpos($inputText, 'done text event') !== false) {
+                $body = implode(
+                    "\n\n",
+                    [
+                        'data: ' . json_encode(
+                            [
+                                'type' => 'response.output_text.done',
+                                'text' => 'done text normalized',
+                            ]
+                        ),
+                        'data: ' . json_encode(
+                            ['type' => 'response.completed', 'response' => ['id' => 'resp_done_text']]
+                        ),
+                        'data: [DONE]',
+                    ]
+                );
+
+                return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+            }
+
+            if (strpos($inputText, 'content part event') !== false) {
+                $body = implode(
+                    "\n\n",
+                    [
+                        'data: ' . json_encode(
+                            [
+                                'type' => 'response.content_part.done',
+                                'part' => [
+                                    'type' => 'output_text',
+                                    'text' => 'content part normalized',
+                                ],
+                            ]
+                        ),
+                        'data: ' . json_encode(
+                            ['type' => 'response.completed', 'response' => ['id' => 'resp_content_part']]
+                        ),
+                        'data: [DONE]',
+                    ]
+                );
+
+                return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+            }
+
+            if (strpos($inputText, 'failed response') !== false) {
+                $body = implode(
+                    "\n\n",
+                    [
+                        'data: ' . json_encode(
+                            [
+                                'type' => 'response.failed',
+                                'response' => [
+                                    'id' => 'resp_failed',
+                                    'status' => 'failed',
+                                    'error' => [
+                                        'code' => 'codex_failed',
+                                        'message' => 'Codex failed while generating a response',
+                                    ],
+                                ],
+                            ]
+                        ),
+                        'data: [DONE]',
+                    ]
+                );
+
+                return new Response(200, ['Content-Type' => 'text/event-stream'], $body);
+            }
+
+            if (strpos($inputText, 'bad request body') !== false) {
+                return new Response(
+                    400,
+                    ['Content-Type' => 'text/plain'],
+                    "Codex says the request payload is invalid\n"
+                );
+            }
+
             if (isset($data['tools'])) {
                 assert(is_array($data['tools']));
                 assert(($data['tools'][0]['type'] ?? null) === 'function');
@@ -197,8 +273,16 @@ $registry->setHttpTransporter(
                     ? implode(
                         "\n\n",
                         [
-                            'data: ' . json_encode(['type' => 'response.output_item.done', 'output_index' => 0, 'item' => $response['output'][0]]),
-                            'data: ' . json_encode(['type' => 'response.completed', 'response' => ['id' => 'resp_tool_streamed']]),
+                            'data: ' . json_encode(
+                                [
+                                    'type' => 'response.output_item.done',
+                                    'output_index' => 0,
+                                    'item' => $response['output'][0],
+                                ]
+                            ),
+                            'data: ' . json_encode(
+                                ['type' => 'response.completed', 'response' => ['id' => 'resp_tool_streamed']]
+                            ),
                             'data: [DONE]',
                         ]
                     )
@@ -294,6 +378,38 @@ $textItemResult = $model->generateTextResult([new UserMessage([new MessagePart('
 assert($textItemResult->toText() === 'completed text normalized');
 
 echo "Codex completed text item smoke passed.\n";
+
+$doneTextResult = $model->generateTextResult([new UserMessage([new MessagePart('done text event')])]);
+assert($doneTextResult->toText() === 'done text normalized');
+
+echo "Codex done text event smoke passed.\n";
+
+$contentPartResult = $model->generateTextResult([new UserMessage([new MessagePart('content part event')])]);
+assert($contentPartResult->toText() === 'content part normalized');
+
+echo "Codex content part event smoke passed.\n";
+
+$failedResponseMessage = '';
+try {
+    $model->generateTextResult([new UserMessage([new MessagePart('failed response')])]);
+} catch (ResponseException $exception) {
+    $failedResponseMessage = $exception->getMessage();
+}
+assert(strpos($failedResponseMessage, 'Codex failed while generating a response') !== false);
+assert(strpos($failedResponseMessage, 'codex_failed') !== false);
+
+echo "Codex failed response smoke passed.\n";
+
+$badRequestMessage = '';
+try {
+    $model->generateTextResult([new UserMessage([new MessagePart('bad request body')])]);
+} catch (ResponseException $exception) {
+    $badRequestMessage = $exception->getMessage();
+}
+assert(strpos($badRequestMessage, 'HTTP 400') !== false);
+assert(strpos($badRequestMessage, 'Codex says the request payload is invalid') !== false);
+
+echo "Codex bad request body smoke passed.\n";
 
 $streamedToolResult = $model->generateTextResult([new UserMessage([new MessagePart('streamed tool item')])]);
 $streamedToolCall = $streamedToolResult->getCandidates()[0]->getMessage()->getParts()[0]->getFunctionCall();

--- a/tests/codex-smoke.php
+++ b/tests/codex-smoke.php
@@ -9,10 +9,7 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\ProviderRegistry;
-use WordPress\OpenAiAiProvider\Codex\CodexOAuthClient;
 use WordPress\OpenAiAiProvider\Codex\CodexProvider;
-use WordPress\OpenAiAiProvider\Codex\CodexRequestAuthentication;
-use WordPress\OpenAiAiProvider\Codex\CodexTokenStore;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/src/autoload.php';
@@ -52,12 +49,7 @@ $registry->setHttpTransporter(
     }
 );
 
-$tokenStore = new CodexTokenStore();
 $registry->registerProvider(CodexProvider::class);
-$registry->setProviderRequestAuthentication(
-    CodexProvider::class,
-    new CodexRequestAuthentication($tokenStore, new CodexOAuthClient($tokenStore))
-);
 
 $model = $registry->getProviderModel('codex', 'gpt-5.5');
 $result = $model->generateTextResult([new UserMessage([new MessagePart('hello')])]);


### PR DESCRIPTION
**This is a demonstrative spike for headless WordPress agents using a Codex subscription. If this were to merge, it should be on top of WordPress core primitives for streaming and authentication**

## Summary
- Add a `codex` provider for ChatGPT subscription-backed Codex access using OAuth token refresh.
- Add Codex text generation support for the Codex Responses endpoint, including required `instructions`, `store=false`, `stream=true`, and buffered SSE parsing.
- Register Codex alongside the existing `openai` provider.
- Refresh expired Codex access tokens through WordPress HTTP when available, persist refreshed token data with `autoload=false`, and keep a PHP stream fallback for non-WordPress package use.

## Dependency
- **Stacked/blocked on:** WordPress/php-ai-client#238, which fixes WordPress/php-ai-client#237 by adding `ProviderWithRequestAuthenticationInterface` support.
- Status checked 2026-05-31: #238 is open, all current checks are green, and it is not merged yet.
- Codex authentication is supplied by the provider via that interface, not by a registration-time API-key bridge.

## Testing
- `php tests/codex-smoke.php`
- `composer phpcs`
- `composer phpstan`

Local testing used the local WordPress/php-ai-client#238 worktree as the installed client dependency so the smoke test exercises provider-supplied authentication.

## Smoke coverage
- Seeds `ai_provider_openai_codex_oauth_tokens` with an expired access token and refresh token.
- Verifies provider ID `codex` is configured when a refresh token is present.
- Verifies the OAuth refresh endpoint is called with the configured refresh token.
- Verifies refreshed access and refresh tokens are persisted with `autoload=false`.
- Verifies outbound Codex requests use the fresh bearer token, `ChatGPT-Account-ID`, and FedRAMP header.
- Verifies Codex buffered SSE response text is parsed from both `response.output_text.delta` and plain `delta` events.

## Notes
- Codex OAuth token values are not stored in this PR. The provider reads token data from constants, the `ai_provider_openai_codex_oauth_tokens` option, or the matching filter.
- No standalone `ai-provider-for-codex` plugin is introduced; this keeps the narrow Codex provider inside `ai-provider-for-openai` pending review evidence to the contrary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the Codex provider/auth/model implementation from the validated spike, adding the smoke test, tightening refresh coverage, and running local verification. Chris remains responsible for review and acceptance.