### PR TITLE
Fix OpenAI function call name mapping

### DIFF
--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -67,6 +67,13 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     private array $openAiFunctionNameMap = [];
 
     /**
+     * Maps original client tool names to OpenAI-safe function names.
+     *
+     * @var array<string, string>
+     */
+    private array $clientFunctionNameMap = [];
+
+    /**
      * {@inheritDoc}
      *
      * @since 1.0.0
@@ -367,10 +374,16 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                     'The function_call typed message part must contain a function call.'
                 );
             }
+            $functionName = $functionCall->getName();
+            if ($functionName === null) {
+                throw new RuntimeException(
+                    'The function_call typed message part must contain a function name.'
+                );
+            }
             return [
                 'type' => 'function_call',
                 'call_id' => $functionCall->getId(),
-                'name' => $this->openAiFunctionName($functionCall->getName()),
+                'name' => $this->openAiFunctionName($functionName),
                 'arguments' => json_encode($functionCall->getArgs()),
             ];
         }
@@ -410,11 +423,11 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     ): array {
         $tools = [];
         $this->openAiFunctionNameMap = [];
+        $this->clientFunctionNameMap = [];
 
         if (is_array($functionDeclarations)) {
             foreach ($functionDeclarations as $functionDeclaration) {
                 $openAiName = $this->openAiFunctionName($functionDeclaration->getName());
-                $this->openAiFunctionNameMap[$openAiName] = $functionDeclaration->getName();
                 $tools[] = [
                     'type' => 'function',
                     'name' => $openAiName,
@@ -637,11 +650,22 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
      */
     private function openAiFunctionName(string $name): string
     {
-        $safe = preg_replace('/[^a-zA-Z0-9_-]+/', '__', $name) ?? '';
-        $safe = trim($safe, '_');
+        if (isset($this->clientFunctionNameMap[$name])) {
+            return $this->clientFunctionNameMap[$name];
+        }
+
+        $safe = preg_replace('/[^a-zA-Z0-9_-]+/', '_', $name) ?? '';
+        $safe = trim($safe, '_-');
         if ($safe === '') {
             $safe = 'tool';
         }
+
+        if ($safe !== $name || isset($this->openAiFunctionNameMap[$safe])) {
+            $safe = substr($safe, 0, 54) . '_' . substr(sha1($name), 0, 8);
+        }
+
+        $this->clientFunctionNameMap[$name] = $safe;
+        $this->openAiFunctionNameMap[$safe] = $name;
 
         return $safe;
     }

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -60,6 +60,13 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
     /**
+     * Maps OpenAI-safe function names back to the original client tool names.
+     *
+     * @var array<string, string>
+     */
+    private array $openAiFunctionNameMap = [];
+
+    /**
      * {@inheritDoc}
      *
      * @since 1.0.0
@@ -363,7 +370,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             return [
                 'type' => 'function_call',
                 'call_id' => $functionCall->getId(),
-                'name' => $functionCall->getName(),
+                'name' => $this->openAiFunctionName($functionCall->getName()),
                 'arguments' => json_encode($functionCall->getArgs()),
             ];
         }
@@ -402,12 +409,15 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         ?WebSearch $webSearch
     ): array {
         $tools = [];
+        $this->openAiFunctionNameMap = [];
 
         if (is_array($functionDeclarations)) {
             foreach ($functionDeclarations as $functionDeclaration) {
+                $openAiName = $this->openAiFunctionName($functionDeclaration->getName());
+                $this->openAiFunctionNameMap[$openAiName] = $functionDeclaration->getName();
                 $tools[] = [
                     'type' => 'function',
-                    'name' => $functionDeclaration->getName(),
+                    'name' => $openAiName,
                     'description' => $functionDeclaration->getDescription(),
                     'parameters' => $functionDeclaration->getParameters(),
                 ];
@@ -607,7 +617,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         $functionCall = new FunctionCall(
             $outputItem['call_id'],
-            $outputItem['name'],
+            $this->originalFunctionName($outputItem['name']),
             $args
         );
 
@@ -615,6 +625,38 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $message = new Message(MessageRoleEnum::model(), [$part]);
 
         return new Candidate($message, FinishReasonEnum::toolCalls());
+    }
+
+    /**
+     * Converts a PHP AI Client function name to an OpenAI-safe function name.
+     *
+     * @since 1.0.0
+     *
+     * @param string $name Original function name.
+     * @return string OpenAI-safe function name.
+     */
+    private function openAiFunctionName(string $name): string
+    {
+        $safe = preg_replace('/[^a-zA-Z0-9_-]+/', '__', $name) ?? '';
+        $safe = trim($safe, '_');
+        if ($safe === '') {
+            $safe = 'tool';
+        }
+
+        return $safe;
+    }
+
+    /**
+     * Restores the original PHP AI Client function name from an OpenAI function call.
+     *
+     * @since 1.0.0
+     *
+     * @param string $name OpenAI function name.
+     * @return string Original function name when known.
+     */
+    private function originalFunctionName(string $name): string
+    {
+        return $this->openAiFunctionNameMap[$name] ?? $name;
     }
 
     /**
@@ -663,7 +705,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             return new MessagePart(
                 new FunctionCall(
                     $contentItem['call_id'],
-                    $contentItem['name'],
+                    $this->originalFunctionName($contentItem['name']),
                     $args
                 )
             );

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -757,8 +757,10 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             isset($this->openAiFunctionNameMap[$safe])
         ) {
             $prefixLength = self::OPENAI_FUNCTION_NAME_MAX_LENGTH - self::OPENAI_FUNCTION_NAME_HASH_LENGTH - 1;
-            $safe = substr($safe, 0, $prefixLength) . '_' . substr(sha1($name), 0, self::OPENAI_FUNCTION_NAME_HASH_LENGTH);
-         }
+            $safe = substr($safe, 0, $prefixLength)
+                . '_'
+                . substr(sha1($name), 0, self::OPENAI_FUNCTION_NAME_HASH_LENGTH);
+        }
 
         $this->clientFunctionNameMap[$name] = $safe;
         $this->openAiFunctionNameMap[$safe] = $name;

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -663,8 +663,6 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             $safe = 'tool';
         }
 
-        if ($safe !== $name || isset($this->openAiFunctionNameMap[$safe])) {
-            $safe = substr($safe, 0, 54) . '_' . substr(sha1($name), 0, 8);
         if (
             $safe !== $name ||
             strlen($safe) > self::OPENAI_FUNCTION_NAME_MAX_LENGTH ||

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -73,6 +73,9 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
      */
     private array $clientFunctionNameMap = [];
 
+    private const OPENAI_FUNCTION_NAME_MAX_LENGTH = 64;
+    private const OPENAI_FUNCTION_NAME_HASH_LENGTH = 8;
+
     /**
      * {@inheritDoc}
      *
@@ -662,7 +665,14 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         if ($safe !== $name || isset($this->openAiFunctionNameMap[$safe])) {
             $safe = substr($safe, 0, 54) . '_' . substr(sha1($name), 0, 8);
-        }
+        if (
+            $safe !== $name ||
+            strlen($safe) > self::OPENAI_FUNCTION_NAME_MAX_LENGTH ||
+            isset($this->openAiFunctionNameMap[$safe])
+        ) {
+            $prefixLength = self::OPENAI_FUNCTION_NAME_MAX_LENGTH - self::OPENAI_FUNCTION_NAME_HASH_LENGTH - 1;
+            $safe = substr($safe, 0, $prefixLength) . '_' . substr(sha1($name), 0, self::OPENAI_FUNCTION_NAME_HASH_LENGTH);
+         }
 
         $this->clientFunctionNameMap[$name] = $safe;
         $this->openAiFunctionNameMap[$safe] = $name;


### PR DESCRIPTION
## Summary
- Maps PHP AI Client function names to OpenAI-safe names when serializing function declarations and function-call history.
- Maps OpenAI-safe function-call names back to the original PHP AI Client names for both top-level and nested Responses API output shapes.
- Keeps provider-specific OpenAI naming constraints out of callers that use canonical tool names such as `client/filesystem-write`.

## Reproduction
See issue #33 for a deterministic reproduction using a simulated OpenAI Responses API payload where the function call is returned as nested `content[].function_call`:

https://github.com/WordPress/ai-provider-for-openai/issues/33

## Why this is provider-owned
OpenAI function names cannot contain `/`, while PHP AI Client callers may use canonical tool names such as `client/filesystem-write`. The OpenAI provider owns translating those canonical names to OpenAI-safe wire names and translating OpenAI responses back before returning results to callers.

## Testing
- `php -l src/Models/OpenAiTextGenerationModel.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the provider-specific function-name mapping gap and drafting the code change; Chris remains responsible for review and testing.