### PR TITLE
Add OpenAI provider profile metadata

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -52,3 +52,48 @@ function register_provider(): void
 }
 
 add_action('init', __NAMESPACE__ . '\\register_provider', 5);
+
+/**
+ * Returns generic provider profile metadata for runtime consumers.
+ *
+ * @since 1.0.4
+ *
+ * @return array<string, mixed> Provider profile metadata.
+ */
+function provider_profile(): array
+{
+    return [
+        'schema' => 'ai-provider/profile/v1',
+        'provider' => 'openai',
+        'name' => 'OpenAI',
+        'base_url' => 'https://api.openai.com/v1',
+        'authentication' => [
+            'type' => 'api_key',
+            'env' => 'OPENAI_API_KEY',
+        ],
+        'plugin_source' => [
+            'type' => 'wordpress-plugin',
+            'slug' => 'ai-provider-for-openai',
+            'path' => __DIR__,
+            'repository' => 'https://github.com/WordPress/ai-provider-for-openai',
+            'composer_package' => 'wordpress/ai-provider-for-openai',
+        ],
+    ];
+}
+
+/**
+ * Registers OpenAI in a generic provider profile registry.
+ *
+ * @since 1.0.4
+ *
+ * @param array<string, mixed> $profiles Provider profiles keyed by provider ID.
+ * @return array<string, mixed> Provider profiles.
+ */
+function register_provider_profile(array $profiles): array
+{
+    $profiles['openai'] = provider_profile();
+
+    return $profiles;
+}
+
+add_filter('ai_provider_profiles', __NAMESPACE__ . '\\register_provider_profile');

--- a/tests/provider-profile-smoke.php
+++ b/tests/provider-profile-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic provider profile metadata.
+ *
+ * Run with: php tests/provider-profile-smoke.php
+ *
+ * @package WordPress\OpenAiAiProvider\Tests
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+if (!function_exists('add_action')) {
+    function add_action(string $hook_name, callable $callback, int $priority = 10): void
+    {
+        unset($hook_name, $callback, $priority);
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter(string $hook_name, callable $callback, int $priority = 10): void
+    {
+        $GLOBALS['__openai_provider_profile_filters'][$hook_name][] = $callback;
+        unset($priority);
+    }
+}
+
+require_once __DIR__ . '/../plugin.php';
+
+$failures = [];
+$passes = 0;
+
+$assert = static function ($expected, $actual, string $label) use (&$failures, &$passes): void {
+    if ($expected === $actual) {
+        ++$passes;
+        echo "PASS {$label}\n";
+        return;
+    }
+
+    $failures[] = sprintf('%s expected %s, got %s', $label, var_export($expected, true), var_export($actual, true));
+    echo "FAIL {$label}\n";
+};
+
+$profile = WordPress\OpenAiAiProvider\provider_profile();
+$assert('ai-provider/profile/v1', $profile['schema'] ?? '', 'profile schema');
+$assert('openai', $profile['provider'] ?? '', 'provider id');
+$assert('https://api.openai.com/v1', $profile['base_url'] ?? '', 'base URL');
+$assert('OPENAI_API_KEY', $profile['authentication']['env'] ?? '', 'auth env');
+$assert('ai-provider-for-openai', $profile['plugin_source']['slug'] ?? '', 'plugin source slug');
+$assert('wordpress/ai-provider-for-openai', $profile['plugin_source']['composer_package'] ?? '', 'composer package');
+$assert(true, is_dir($profile['plugin_source']['path'] ?? ''), 'plugin source path exists');
+
+$profiles = [];
+foreach ($GLOBALS['__openai_provider_profile_filters']['ai_provider_profiles'] ?? [] as $callback) {
+    $profiles = $callback($profiles);
+}
+$assert('openai', $profiles['openai']['provider'] ?? '', 'profile filter registration');
+
+if (!empty($failures)) {
+    echo "\nprovider profile smoke failed:\n" . implode("\n", $failures) . "\n";
+    exit(1);
+}
+
+echo "\nprovider profile smoke passed ({$passes} assertions)\n";


### PR DESCRIPTION
## Summary
- expose OpenAI provider profile metadata through a generic `ai_provider_profiles` registry filter
- include provider id, base URL, auth env, and plugin source metadata for runtime consumers
- add a pure-PHP smoke test for the profile contract

## Tests
- `php -l plugin.php`
- `php -l tests/provider-profile-smoke.php`
- `php tests/provider-profile-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the provider profile metadata, smoke coverage, and PR text; Chris remains responsible for review and validation.