### PR TITLE
Provide Data Machine image generation defaults

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -52,3 +52,29 @@ function register_provider(): void
 }
 
 add_action('init', __NAMESPACE__ . '\\register_provider', 5);
+
+/**
+ * Supplies OpenAI defaults for Data Machine's image generation capability.
+ *
+ * @since n.e.x.t
+ *
+ * @param array<string, mixed> $defaults Existing capability defaults.
+ * @param string              $capability Capability identifier.
+ * @return array<string, mixed> Filtered capability defaults.
+ */
+function filter_datamachine_ai_capability_defaults(array $defaults, string $capability): array
+{
+    if ($capability !== 'image_generation') {
+        return $defaults;
+    }
+
+    return array_merge(
+        $defaults,
+        [
+            'provider' => 'openai',
+            'model' => 'gpt-image-1',
+        ]
+    );
+}
+
+add_filter('datamachine_ai_capability_defaults', __NAMESPACE__ . '\\filter_datamachine_ai_capability_defaults', 10, 2);


### PR DESCRIPTION
## Summary
- Adds a provider-owned `datamachine_ai_capability_defaults` filter callback for Data Machine's `image_generation` capability.
- Supplies OpenAI defaults of provider `openai` and model `gpt-image-1` from the OpenAI provider plugin instead of Data Machine core.
- Leaves non-image capabilities unchanged.

## Dependency
- Companion to https://github.com/Extra-Chill/data-machine/pull/2714, which introduces the generic provider-neutral filter contract in Data Machine.

## Testing
- `composer lint`
- Runtime smoke check with WordPress hook stubs confirming the filter registration and image-generation defaults.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider hook, ran verification, and prepared this PR for Chris to review.
