### PR TITLE
Add an extensible OpenAI API profile contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The provider uses the `OPENAI_API_KEY` environment variable for authentication. 
 putenv('OPENAI_API_KEY=your-api-key');
 ```
 
+## Extending OpenAI API profiles
+
+The provider supports alternate OpenAI API dialects without requiring a fork. A custom request authentication implementation can implement `OpenAiApiProfileAwareAuthenticationInterface` and return an `OpenAiApiProfileInterface` instance. The profile can adapt operation support, endpoint URLs, requests, responses, model metadata, and model-cache isolation while the authentication object remains responsible for credentials.
+
+WordPress integrations may also supply or replace a profile with the `ai_provider_for_openai_api_profile` filter. Profile request changes are applied before authentication, and response normalization is applied only after a successful HTTP response. Because a profile can change where authenticated requests are sent, only trusted code should provide one.
+
+API-key authentication does not use a profile, so its existing request and cache behavior remains unchanged.
+
 ## License
 
 GPL-2.0-or-later

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ putenv('OPENAI_API_KEY=your-api-key');
 
 The provider supports alternate OpenAI API dialects without requiring a fork. A custom request authentication implementation can implement `OpenAiApiProfileAwareAuthenticationInterface` and return an `OpenAiApiProfileInterface` instance. The profile can adapt operation support, endpoint URLs, requests, responses, model metadata, and model-cache isolation while the authentication object remains responsible for credentials.
 
+The PHP AI Client currently validates replacement OpenAI authentication against its API-key DTO. Pass profile-aware authentication through `OpenAiApiProfileRequestAuthenticationAdapter` before registering it with `setProviderRequestAuthentication()`. The adapter only satisfies that registry compatibility check; request authentication and profile selection are delegated to the wrapped implementation.
+
 WordPress integrations may also supply or replace a profile with the `ai_provider_for_openai_api_profile` filter. Profile request changes are applied before authentication, and response normalization is applied only after a successful HTTP response. Because a profile can change where authenticated requests are sent, only trusted code should provide one.
 
 API-key authentication does not use a profile, so its existing request and cache behavior remains unchanged.

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,12 @@
     "scripts": {
         "lint": [
             "@phpcs",
-            "@phpstan"
+            "@phpstan",
+            "@test"
         ],
         "phpcbf": "phpcbf",
         "phpcs": "phpcs",
-        "phpstan": "phpstan analyze --memory-limit=256M"
+        "phpstan": "phpstan analyze --memory-limit=256M",
+        "test": "@php tests/run.php"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
     <!-- Scan these files -->
     <file>src</file>
     <file>plugin.php</file>
+    <file>tests</file>
 
     <!-- Ignore vendor directory -->
     <exclude-pattern>*/vendor/*</exclude-pattern>

--- a/src/Authentication/OpenAiApiProfileRequestAuthenticationAdapter.php
+++ b/src/Authentication/OpenAiApiProfileRequestAuthenticationAdapter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Authentication;
+
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileAwareAuthenticationInterface;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileInterface;
+
+/**
+ * Adapts profile-aware authentication to the PHP AI Client registry contract.
+ *
+ * The PHP AI Client currently declares API-key authentication as the OpenAI
+ * provider's authentication method and therefore requires replacement
+ * authentication to extend ApiKeyRequestAuthentication. This adapter keeps
+ * that compatibility detail out of alternate authentication implementations.
+ * It is a runtime-only adapter and should not be used as a serialized
+ * credential value.
+ *
+ * @since 1.1.0
+ */
+final class OpenAiApiProfileRequestAuthenticationAdapter extends ApiKeyRequestAuthentication implements
+    OpenAiApiProfileAwareAuthenticationInterface
+{
+    /**
+     * The profile-aware authentication implementation.
+     *
+     * @var OpenAiApiProfileAwareAuthenticationInterface
+     */
+    private OpenAiApiProfileAwareAuthenticationInterface $authentication;
+
+    /**
+     * Constructor.
+     *
+     * @since 1.1.0
+     *
+     * @param OpenAiApiProfileAwareAuthenticationInterface $authentication Authentication to adapt.
+     */
+    public function __construct(OpenAiApiProfileAwareAuthenticationInterface $authentication)
+    {
+        /*
+         * This value is never sent. authenticateRequest() always delegates to
+         * the wrapped authentication implementation.
+         */
+        parent::__construct('openai-api-profile-managed-authentication');
+        $this->authentication = $authentication;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function authenticateRequest(Request $request): Request
+    {
+        return $this->authentication->authenticateRequest($request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOpenAiApiProfile(): OpenAiApiProfileInterface
+    {
+        return $this->authentication->getOpenAiApiProfile();
+    }
+}

--- a/src/Contracts/OpenAiApiProfileAwareAuthenticationInterface.php
+++ b/src/Contracts/OpenAiApiProfileAwareAuthenticationInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Contracts;
+
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+
+/**
+ * Identifies request authentication that uses an alternate OpenAI API profile.
+ *
+ * Coupling the profile to its authentication object prevents the provider from
+ * inferring an API dialect from a concrete authentication implementation.
+ *
+ * @since 1.1.0
+ */
+interface OpenAiApiProfileAwareAuthenticationInterface extends RequestAuthenticationInterface
+{
+    /**
+     * Gets the API profile associated with this request authentication.
+     *
+     * @since 1.1.0
+     *
+     * @return OpenAiApiProfileInterface The associated API profile.
+     */
+    public function getOpenAiApiProfile(): OpenAiApiProfileInterface;
+}

--- a/src/Contracts/OpenAiApiProfileInterface.php
+++ b/src/Contracts/OpenAiApiProfileInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Contracts;
+
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+/**
+ * Describes an alternate OpenAI API dialect for a request authentication type.
+ *
+ * Profiles may adapt endpoints, payloads, and responses while the provider
+ * continues to own the common model behavior. Implementations are trusted
+ * code because they can select the destination for authenticated requests.
+ *
+ * @since 1.1.0
+ */
+interface OpenAiApiProfileInterface
+{
+    /**
+     * Gets a stable, non-secret value used to separate model metadata caches.
+     *
+     * The provider hashes this value before using it in a cache key.
+     *
+     * @since 1.1.0
+     *
+     * @return string The profile cache identity.
+     */
+    public function getCacheKey(): string;
+
+    /**
+     * Checks whether the profile supports an OpenAI provider operation.
+     *
+     * @since 1.1.0
+     *
+     * @param string $operation One of the OpenAiApiOperation constants.
+     * @return bool True if the operation is supported, false otherwise.
+     */
+    public function supportsOperation(string $operation): bool;
+
+    /**
+     * Gets the endpoint URL for an OpenAI provider operation.
+     *
+     * Implementations must only return destinations that they trust to receive
+     * credentials from the associated request authentication object.
+     *
+     * @since 1.1.0
+     *
+     * @param string $defaultUrl The URL used by the standard OpenAI API profile.
+     * @param string $path The endpoint path relative to the API base URL.
+     * @param string $operation One of the OpenAiApiOperation constants.
+     * @return string The endpoint URL to request.
+     */
+    public function getRequestUrl(string $defaultUrl, string $path, string $operation): string;
+
+    /**
+     * Adapts a request before authentication credentials are applied.
+     *
+     * @since 1.1.0
+     *
+     * @param Request $request The standard OpenAI API request.
+     * @param string $operation One of the OpenAiApiOperation constants.
+     * @return Request The adapted request.
+     */
+    public function prepareRequest(Request $request, string $operation): Request;
+
+    /**
+     * Normalizes a successful response before the standard response parser runs.
+     *
+     * @since 1.1.0
+     *
+     * @param Response $response The successful response to normalize.
+     * @param string $operation One of the OpenAiApiOperation constants.
+     * @return Response The normalized response.
+     */
+    public function normalizeResponse(Response $response, string $operation): Response;
+
+    /**
+     * Parses a profile-specific list-models response.
+     *
+     * @since 1.1.0
+     *
+     * @param Response $response The successful list-models response.
+     * Return null to use the provider's standard OpenAI model metadata
+     * parser after response normalization.
+     *
+     * @return list<ModelMetadata>|null The available model metadata, or null to use the standard parser.
+     */
+    public function parseModelMetadataList(Response $response): ?array;
+}

--- a/src/Metadata/OpenAiModelMetadataDirectory.php
+++ b/src/Metadata/OpenAiModelMetadataDirectory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\OpenAiAiProvider\Metadata;
 
+use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
@@ -16,7 +17,9 @@ use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleModelMetadataDirectory;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiOperation;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+use WordPress\OpenAiAiProvider\Traits\OpenAiApiProfileContextTrait;
 
 /**
  * Class for the OpenAI model metadata directory.
@@ -29,6 +32,8 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  */
 class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadataDirectory
 {
+    use OpenAiApiProfileContextTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -36,12 +41,30 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
      */
     protected function createRequest(HttpMethodEnum $method, string $path, array $headers = [], $data = null): Request
     {
-        return new Request(
+        $apiProfile = $this->getOpenAiApiProfile();
+        $operation = OpenAiApiOperation::LIST_MODELS;
+
+        if ($apiProfile !== null && !$apiProfile->supportsOperation($operation)) {
+            throw new RuntimeException(
+                'The selected OpenAI API profile does not support listing models.'
+            );
+        }
+
+        $defaultUrl = OpenAiProvider::url($path);
+        $requestUrl = $apiProfile !== null
+            ? $apiProfile->getRequestUrl($defaultUrl, $path, $operation)
+            : $defaultUrl;
+
+        $request = new Request(
             $method,
-            OpenAiProvider::url($path),
+            $requestUrl,
             $headers,
             $data
         );
+
+        return $apiProfile !== null
+            ? $apiProfile->prepareRequest($request, $operation)
+            : $request;
     }
 
     /**
@@ -51,6 +74,22 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
      */
     protected function parseResponseToModelMetadataList(Response $response): array
     {
+        $apiProfile = $this->getOpenAiApiProfile();
+        if ($apiProfile !== null) {
+            $operation = OpenAiApiOperation::LIST_MODELS;
+            if (!$apiProfile->supportsOperation($operation)) {
+                throw new RuntimeException(
+                    'The selected OpenAI API profile does not support listing models.'
+                );
+            }
+
+            $response = $apiProfile->normalizeResponse($response, $operation);
+            $profileModels = $apiProfile->parseModelMetadataList($response);
+            if ($profileModels !== null) {
+                return $profileModels;
+            }
+        }
+
         /** @var ModelsResponseData $responseData */
         $responseData = $response->getData();
         if (!isset($responseData['data']) || !$responseData['data']) {
@@ -285,6 +324,34 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
         usort($models, [$this, 'modelSortCallback']);
 
         return $models;
+    }
+
+    /**
+     * Separates alternate API profile model catalogs in the SDK cache.
+     *
+     * The standard API profile retains its existing cache key. Alternate
+     * profile identities are hashed so account identifiers and other profile
+     * details never appear in persistent cache keys.
+     *
+     * @since 1.1.0
+     *
+     * @return string The cache key prefix.
+     */
+    protected function getBaseCacheKey(): string
+    {
+        $baseCacheKey = parent::getBaseCacheKey();
+
+        $apiProfile = $this->getOpenAiApiProfile();
+
+        if ($apiProfile === null) {
+            return $baseCacheKey;
+        }
+
+        $profileCacheKey = $apiProfile->getCacheKey();
+
+        return $baseCacheKey
+            . '_profile_'
+            . substr(hash('sha256', $profileCacheKey), 0, 16);
     }
 
     /**

--- a/src/Models/OpenAiImageGenerationModel.php
+++ b/src/Models/OpenAiImageGenerationModel.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace WordPress\OpenAiAiProvider\Models;
 
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleImageGenerationModel;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiOperation;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+use WordPress\OpenAiAiProvider\Traits\OpenAiApiProfileContextTrait;
 
 /**
  * Class for an OpenAI image generation model using the Images API.
@@ -28,6 +32,15 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  */
 class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGenerationModel
 {
+    use OpenAiApiProfileContextTrait;
+
+    /**
+     * The operation used by the active image request.
+     *
+     * @var string
+     */
+    private string $apiOperation = OpenAiApiOperation::GENERATE_IMAGE;
+
     /**
      * {@inheritDoc}
      *
@@ -42,7 +55,23 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
      */
     public function generateImageResult(array $prompt): GenerativeAiResult
     {
-        if ($this->promptContainsImage($prompt)) {
+        $isEdit = $this->promptContainsImage($prompt);
+        $this->apiOperation = $isEdit
+            ? OpenAiApiOperation::EDIT_IMAGE
+            : OpenAiApiOperation::GENERATE_IMAGE;
+
+        $apiProfile = $this->getOpenAiApiProfile();
+        if ($apiProfile !== null && !$apiProfile->supportsOperation($this->apiOperation)) {
+            $operationLabel = $isEdit ? 'image editing' : 'image generation';
+            throw new RuntimeException(
+                sprintf(
+                    'The selected OpenAI API profile does not support %s.',
+                    $operationLabel
+                )
+            );
+        }
+
+        if ($isEdit) {
             return $this->generateImageEditResult($prompt);
         }
 
@@ -82,13 +111,43 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
         array $headers = [],
         $data = null
     ): Request {
-        return new Request(
+        $apiProfile = $this->getOpenAiApiProfile();
+        $defaultUrl = OpenAiProvider::url($path);
+        $requestUrl = $apiProfile !== null
+            ? $apiProfile->getRequestUrl($defaultUrl, $path, $this->apiOperation)
+            : $defaultUrl;
+
+        $request = new Request(
             $method,
-            OpenAiProvider::url($path),
+            $requestUrl,
             $headers,
             $data,
             $this->getRequestOptions()
         );
+
+        return $apiProfile !== null
+            ? $apiProfile->prepareRequest($request, $this->apiOperation)
+            : $request;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.1.0
+     */
+    protected function parseResponseToGenerativeAiResult(
+        Response $response,
+        string $expectedMimeType = 'image/png'
+    ): GenerativeAiResult {
+        $apiProfile = $this->getOpenAiApiProfile();
+        if ($apiProfile !== null) {
+            $response = $apiProfile->normalizeResponse(
+                $response,
+                $this->apiOperation
+            );
+        }
+
+        return parent::parseResponseToGenerativeAiResult($response, $expectedMimeType);
     }
 
     /**

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -24,7 +24,9 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\WebSearch;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiOperation;
 use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+use WordPress\OpenAiAiProvider\Traits\OpenAiApiProfileContextTrait;
 
 /**
  * Class for an OpenAI text generation model using the Responses API.
@@ -62,6 +64,8 @@ use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
  */
 class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
+    use OpenAiApiProfileContextTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -72,21 +76,42 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $httpTransporter = $this->getHttpTransporter();
 
         $params = $this->prepareGenerateTextParams($prompt);
+        $authentication = $this->getRequestAuthentication();
+        $apiProfile = $this->getOpenAiApiProfile();
+        $operation = OpenAiApiOperation::GENERATE_TEXT;
+
+        if ($apiProfile !== null && !$apiProfile->supportsOperation($operation)) {
+            throw new RuntimeException(
+                'The selected OpenAI API profile does not support text generation.'
+            );
+        }
+
+        $defaultUrl = OpenAiProvider::url('responses');
+        $requestUrl = $apiProfile !== null
+            ? $apiProfile->getRequestUrl($defaultUrl, 'responses', $operation)
+            : $defaultUrl;
 
         $request = new Request(
             HttpMethodEnum::POST(),
-            OpenAiProvider::url('responses'),
+            $requestUrl,
             ['Content-Type' => 'application/json'],
             $params,
             $this->getRequestOptions()
         );
 
+        if ($apiProfile !== null) {
+            $request = $apiProfile->prepareRequest($request, $operation);
+        }
+
         // Add authentication credentials to the request.
-        $request = $this->getRequestAuthentication()->authenticateRequest($request);
+        $request = $authentication->authenticateRequest($request);
 
         // Send and process the request.
         $response = $httpTransporter->send($request);
         ResponseUtil::throwIfNotSuccessful($response);
+        if ($apiProfile !== null) {
+            $response = $apiProfile->normalizeResponse($response, $operation);
+        }
         return $this->parseResponseToGenerativeAiResult($response);
     }
 

--- a/src/Provider/OpenAiApiOperation.php
+++ b/src/Provider/OpenAiApiOperation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Provider;
+
+/**
+ * Operation identifiers passed to OpenAI API profiles.
+ *
+ * This uses class constants instead of a native enum to retain PHP 7.4 support.
+ *
+ * @since 1.1.0
+ */
+final class OpenAiApiOperation
+{
+    public const LIST_MODELS = 'list_models';
+    public const GENERATE_TEXT = 'generate_text';
+    public const GENERATE_IMAGE = 'generate_image';
+    public const EDIT_IMAGE = 'edit_image';
+
+    /**
+     * This class only contains constants and cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Provider/OpenAiApiProfileResolver.php
+++ b/src/Provider/OpenAiApiProfileResolver.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Provider;
+
+use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileAwareAuthenticationInterface;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileInterface;
+
+/**
+ * Resolves an alternate OpenAI API profile for request authentication.
+ *
+ * @since 1.1.0
+ */
+final class OpenAiApiProfileResolver
+{
+    /**
+     * Resolves the API profile associated with request authentication.
+     *
+     * The resolver itself does not cache results. Provider objects pin the
+     * result for their currently bound request authentication and resolve it
+     * again when new authentication is bound. A profile is trusted code: it
+     * can route authenticated requests to a different endpoint and must
+     * validate that destination.
+     *
+     * @since 1.1.0
+     *
+     * @param RequestAuthenticationInterface $authentication The request authentication.
+     * @return OpenAiApiProfileInterface|null The alternate profile, or null for the standard API.
+     */
+    public static function resolve(
+        RequestAuthenticationInterface $authentication
+    ): ?OpenAiApiProfileInterface {
+        $profile = $authentication instanceof OpenAiApiProfileAwareAuthenticationInterface
+            ? $authentication->getOpenAiApiProfile()
+            : null;
+
+        if (function_exists('apply_filters')) {
+            /**
+             * Filters the OpenAI API profile used with request authentication.
+             *
+             * A profile controls where authenticated requests are sent. Only
+             * trusted code should return a profile from this filter.
+             *
+             * @since 1.1.0
+             *
+             * @param OpenAiApiProfileInterface|null $profile The resolved profile, if any.
+             * @param RequestAuthenticationInterface $authentication The request authentication.
+             */
+            $profile = apply_filters(
+                'ai_provider_for_openai_api_profile',
+                $profile,
+                $authentication
+            );
+        }
+
+        if ($profile !== null && !$profile instanceof OpenAiApiProfileInterface) {
+            throw new RuntimeException(
+                'The OpenAI API profile must implement OpenAiApiProfileInterface or be null.'
+            );
+        }
+
+        return $profile;
+    }
+
+    /**
+     * This class only contains static methods and cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Traits/OpenAiApiProfileContextTrait.php
+++ b/src/Traits/OpenAiApiProfileContextTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Traits;
+
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileInterface;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiProfileResolver;
+
+/**
+ * Pins an OpenAI API profile to the currently bound request authentication.
+ *
+ * Resolving once ensures every stage of an operation uses the same trusted
+ * profile for its endpoint, request preparation, response normalization, and
+ * cache namespace. Rebinding authentication clears the pinned profile.
+ *
+ * @since 1.1.0
+ */
+trait OpenAiApiProfileContextTrait
+{
+    /**
+     * The profile resolved for the bound request authentication.
+     *
+     * @var OpenAiApiProfileInterface|null
+     */
+    private ?OpenAiApiProfileInterface $openAiApiProfile = null;
+
+    /**
+     * Whether a profile has been resolved for the bound authentication.
+     *
+     * This flag distinguishes a resolved standard API profile (null) from a
+     * context that has not been resolved yet.
+     *
+     * @var bool
+     */
+    private bool $openAiApiProfileResolved = false;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.1.0
+     */
+    public function setRequestAuthentication(
+        RequestAuthenticationInterface $requestAuthentication
+    ): void {
+        parent::setRequestAuthentication($requestAuthentication);
+
+        $this->openAiApiProfile = null;
+        $this->openAiApiProfileResolved = false;
+    }
+
+    /**
+     * Gets the profile pinned to the bound request authentication.
+     *
+     * @since 1.1.0
+     *
+     * @return OpenAiApiProfileInterface|null The alternate profile, or null for the standard API.
+     */
+    protected function getOpenAiApiProfile(): ?OpenAiApiProfileInterface
+    {
+        if (!$this->openAiApiProfileResolved) {
+            $this->openAiApiProfile = OpenAiApiProfileResolver::resolve(
+                $this->getRequestAuthentication()
+            );
+            $this->openAiApiProfileResolved = true;
+        }
+
+        return $this->openAiApiProfile;
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,739 @@
+<?php
+
+declare(strict_types=1);
+
+// Standalone contract tests necessarily declare symbols and execute a runner.
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+
+use WordPress\AiClient\Common\Exception\RuntimeException as AiRuntimeException;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileAwareAuthenticationInterface;
+use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileInterface;
+use WordPress\OpenAiAiProvider\Metadata\OpenAiModelMetadataDirectory;
+use WordPress\OpenAiAiProvider\Models\OpenAiImageGenerationModel;
+use WordPress\OpenAiAiProvider\Models\OpenAiTextGenerationModel;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiOperation;
+use WordPress\OpenAiAiProvider\Provider\OpenAiApiProfileResolver;
+
+/** @var array<string, list<callable>> */
+$GLOBALS['openai_profile_test_filters'] = [];
+
+/**
+ * Minimal WordPress filter implementation for resolver contract tests.
+ *
+ * @param mixed $value The value being filtered.
+ * @param mixed ...$args Additional filter arguments.
+ * @return mixed The filtered value.
+ */
+function apply_filters(string $hookName, $value, ...$args)
+{
+    $callbacks = $GLOBALS['openai_profile_test_filters'][$hookName] ?? [];
+    foreach ($callbacks as $callback) {
+        $value = $callback($value, ...$args);
+    }
+
+    return $value;
+}
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+require dirname(__DIR__) . '/src/autoload.php';
+
+/**
+ * Shared event trace for request-order assertions.
+ */
+final class OpenAiProfileTestTrace
+{
+    /** @var list<string> */
+    public array $events = [];
+}
+
+/**
+ * Configurable alternate API profile used by the contract tests.
+ */
+final class OpenAiProfileTestProfile implements OpenAiApiProfileInterface
+{
+    private string $baseUrl;
+    private string $cacheKey;
+
+    /** @var list<ModelMetadata>|null */
+    private ?array $parsedModels = null;
+
+    /** @var list<string> */
+    private array $supportedOperations;
+
+    private bool $cacheKeyFailure = false;
+    private ?Response $normalizedResponse = null;
+    private ?string $normalizedText = null;
+    private OpenAiProfileTestTrace $trace;
+
+    /** @var list<array{defaultUrl: string, path: string, operation: string}> */
+    public array $urlCalls = [];
+
+    /**
+     * @param list<string> $supportedOperations Supported operation identifiers.
+     */
+    public function __construct(
+        string $cacheKey,
+        array $supportedOperations,
+        OpenAiProfileTestTrace $trace,
+        string $baseUrl = 'https://profile.example/v1'
+    ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
+        $this->cacheKey = $cacheKey;
+        $this->supportedOperations = $supportedOperations;
+        $this->trace = $trace;
+    }
+
+    public function getCacheKey(): string
+    {
+        if ($this->cacheKeyFailure) {
+            throw new \RuntimeException('The profile cache identity is unavailable.');
+        }
+
+        return $this->cacheKey;
+    }
+
+    public function supportsOperation(string $operation): bool
+    {
+        return in_array($operation, $this->supportedOperations, true);
+    }
+
+    public function getRequestUrl(
+        string $defaultUrl,
+        string $path,
+        string $operation
+    ): string {
+        $this->urlCalls[] = [
+            'defaultUrl' => $defaultUrl,
+            'path' => $path,
+            'operation' => $operation,
+        ];
+        $this->trace->events[] = 'url:' . $operation;
+
+        return $this->baseUrl . '/' . ltrim($path, '/');
+    }
+
+    public function prepareRequest(Request $request, string $operation): Request
+    {
+        $this->trace->events[] = 'prepare:' . $operation;
+
+        return $request->withHeader('X-Profile-Prepared', $operation);
+    }
+
+    public function normalizeResponse(Response $response, string $operation): Response
+    {
+        $this->trace->events[] = 'normalize:' . $operation;
+        if ($this->normalizedResponse !== null) {
+            return $this->normalizedResponse;
+        }
+        if ($this->normalizedText === null) {
+            return $response;
+        }
+
+        return openai_profile_test_text_response($this->normalizedText);
+    }
+
+    public function parseModelMetadataList(Response $response): ?array
+    {
+        unset($response);
+        $this->trace->events[] = 'parse-models';
+
+        return $this->parsedModels;
+    }
+
+    /**
+     * Supplies metadata returned by parseModelMetadataList().
+     *
+     * @param list<ModelMetadata> $models Model metadata list.
+     */
+    public function setParsedModels(array $models): void
+    {
+        $this->parsedModels = $models;
+    }
+
+    /**
+     * Makes normalizeResponse() return a standard Responses API payload.
+     */
+    public function setNormalizedText(string $text): void
+    {
+        $this->normalizedText = $text;
+    }
+
+    /**
+     * Makes normalizeResponse() return a specific response.
+     */
+    public function setNormalizedResponse(Response $response): void
+    {
+        $this->normalizedResponse = $response;
+    }
+
+    /**
+     * Makes getCacheKey() fail for fail-closed cache tests.
+     */
+    public function failCacheKeyLookup(): void
+    {
+        $this->cacheKeyFailure = true;
+    }
+}
+
+/**
+ * Authentication carrying a profile, with an assertion that preparation ran first.
+ */
+final class OpenAiProfileTestAuthentication extends ApiKeyRequestAuthentication implements
+    OpenAiApiProfileAwareAuthenticationInterface
+{
+    private OpenAiApiProfileInterface $profile;
+    private OpenAiProfileTestTrace $trace;
+
+    public int $profileResolutionCount = 0;
+
+    public function __construct(
+        OpenAiApiProfileInterface $profile,
+        OpenAiProfileTestTrace $trace,
+        string $apiKey = 'profile-test-key'
+    ) {
+        parent::__construct($apiKey);
+        $this->profile = $profile;
+        $this->trace = $trace;
+    }
+
+    public function getOpenAiApiProfile(): OpenAiApiProfileInterface
+    {
+        $this->profileResolutionCount++;
+
+        return $this->profile;
+    }
+
+    public function authenticateRequest(Request $request): Request
+    {
+        if (!$request->hasHeader('X-Profile-Prepared')) {
+            throw new \RuntimeException('The profile request was not prepared before authentication.');
+        }
+
+        $this->trace->events[] = 'authenticate';
+
+        return parent::authenticateRequest($request);
+    }
+}
+
+/**
+ * Capturing HTTP transporter for request and short-circuit assertions.
+ */
+final class OpenAiProfileTestTransporter implements HttpTransporterInterface
+{
+    public ?Request $request = null;
+    public int $sendCount = 0;
+
+    private Response $response;
+    private ?OpenAiProfileTestTrace $trace;
+
+    public function __construct(Response $response, ?OpenAiProfileTestTrace $trace = null)
+    {
+        $this->response = $response;
+        $this->trace = $trace;
+    }
+
+    public function send(Request $request, ?RequestOptions $options = null): Response
+    {
+        unset($options);
+        $this->request = $request;
+        $this->sendCount++;
+        if ($this->trace !== null) {
+            $this->trace->events[] = 'transport';
+        }
+
+        return $this->response;
+    }
+}
+
+/**
+ * Exposes the protected cache prefix for isolation contract tests.
+ */
+final class OpenAiProfileTestMetadataDirectory extends OpenAiModelMetadataDirectory
+{
+    public function baseCacheKey(): string
+    {
+        return $this->getBaseCacheKey();
+    }
+}
+
+/**
+ * Resets global test state between contract tests.
+ */
+function openai_profile_test_reset(): void
+{
+    $GLOBALS['openai_profile_test_filters'] = [];
+}
+
+/**
+ * @param mixed $actual Actual value.
+ * @param mixed $expected Expected value.
+ */
+function openai_profile_test_same($actual, $expected, string $message = ''): void
+{
+    if ($actual === $expected) {
+        return;
+    }
+
+    throw new \RuntimeException(
+        ($message !== '' ? $message . ': ' : '')
+        . 'expected ' . var_export($expected, true)
+        . ', got ' . var_export($actual, true)
+    );
+}
+
+/**
+ * @param mixed $value Value expected to be truthy.
+ */
+function openai_profile_test_true($value, string $message = ''): void
+{
+    openai_profile_test_same((bool) $value, true, $message);
+}
+
+/**
+ * Creates metadata for a test model.
+ *
+ * @param object $capability Capability enum value.
+ */
+function openai_profile_test_model_metadata(string $id, $capability): ModelMetadata
+{
+    return new ModelMetadata($id, $id, [$capability], []);
+}
+
+/**
+ * Creates provider metadata for a test model.
+ */
+function openai_profile_test_provider_metadata(): ProviderMetadata
+{
+    return new ProviderMetadata('openai', 'OpenAI', ProviderTypeEnum::cloud());
+}
+
+/**
+ * Creates a successful standard Responses API response.
+ */
+function openai_profile_test_text_response(string $text): Response
+{
+    $body = json_encode([
+        'id' => 'response-contract-test',
+        'status' => 'completed',
+        'output' => [
+            [
+                'type' => 'message',
+                'role' => 'assistant',
+                'status' => 'completed',
+                'content' => [
+                    [
+                        'type' => 'output_text',
+                        'text' => $text,
+                    ],
+                ],
+            ],
+        ],
+        'usage' => [
+            'input_tokens' => 2,
+            'output_tokens' => 3,
+            'total_tokens' => 5,
+        ],
+    ]);
+    if (!is_string($body)) {
+        throw new \RuntimeException('The test response could not be encoded.');
+    }
+
+    return new Response(200, ['Content-Type' => 'application/json'], $body);
+}
+
+/**
+ * Creates a successful standard Images API response.
+ */
+function openai_profile_test_image_response(string $imageData): Response
+{
+    $body = json_encode([
+        'created' => 1234567890,
+        'data' => [
+            ['b64_json' => base64_encode($imageData)],
+        ],
+        'usage' => [
+            'input_tokens' => 1,
+            'output_tokens' => 2,
+            'total_tokens' => 3,
+        ],
+    ]);
+    if (!is_string($body)) {
+        throw new \RuntimeException('The test image response could not be encoded.');
+    }
+
+    return new Response(200, ['Content-Type' => 'application/json'], $body);
+}
+
+/**
+ * Creates a simple user prompt.
+ *
+ * @return list<Message>
+ */
+function openai_profile_test_prompt(): array
+{
+    return [new Message(MessageRoleEnum::user(), [new MessagePart('Hello')])];
+}
+
+/** @var array<string, callable> $tests */
+$tests = [];
+
+$tests['plain API-key behavior remains unchanged'] = static function (): void {
+    openai_profile_test_reset();
+    $authentication = new ApiKeyRequestAuthentication('standard-api-key');
+    openai_profile_test_same(OpenAiApiProfileResolver::resolve($authentication), null);
+
+    $transporter = new OpenAiProfileTestTransporter(
+        openai_profile_test_text_response('Standard API response')
+    );
+    $model = new OpenAiTextGenerationModel(
+        openai_profile_test_model_metadata('gpt-standard', CapabilityEnum::textGeneration()),
+        openai_profile_test_provider_metadata()
+    );
+    $model->setRequestAuthentication($authentication);
+    $model->setHttpTransporter($transporter);
+
+    $result = $model->generateTextResult(openai_profile_test_prompt());
+    openai_profile_test_same($result->toText(), 'Standard API response');
+    openai_profile_test_same($transporter->sendCount, 1);
+    openai_profile_test_true($transporter->request instanceof Request);
+    openai_profile_test_same(
+        $transporter->request->getUri(),
+        'https://api.openai.com/v1/responses'
+    );
+    openai_profile_test_same(
+        $transporter->request->getHeaderAsString('Authorization'),
+        'Bearer standard-api-key'
+    );
+    openai_profile_test_same($transporter->request->hasHeader('X-Profile-Prepared'), false);
+
+    $requestData = $transporter->request->getData();
+    openai_profile_test_true(is_array($requestData));
+    openai_profile_test_same($requestData['model'] ?? null, 'gpt-standard');
+    openai_profile_test_true(isset($requestData['input']));
+};
+
+$tests['profile prepares before auth and normalizes successful response'] = static function (): void {
+    openai_profile_test_reset();
+    $trace = new OpenAiProfileTestTrace();
+    $profile = new OpenAiProfileTestProfile(
+        'profile-text',
+        [OpenAiApiOperation::GENERATE_TEXT],
+        $trace
+    );
+    $profile->setNormalizedText('Normalized profile response');
+    $authentication = new OpenAiProfileTestAuthentication($profile, $trace);
+    $rawResponse = new Response(
+        200,
+        ['Content-Type' => 'application/x-profile-response'],
+        '{"alternateText":"raw"}'
+    );
+    $transporter = new OpenAiProfileTestTransporter($rawResponse, $trace);
+    $model = new OpenAiTextGenerationModel(
+        openai_profile_test_model_metadata('gpt-profile', CapabilityEnum::textGeneration()),
+        openai_profile_test_provider_metadata()
+    );
+    $model->setRequestAuthentication($authentication);
+    $model->setHttpTransporter($transporter);
+
+    $result = $model->generateTextResult(openai_profile_test_prompt());
+    openai_profile_test_same($result->toText(), 'Normalized profile response');
+    openai_profile_test_same(
+        $authentication->profileResolutionCount,
+        1,
+        'A text model must pin one profile for the bound authentication'
+    );
+    openai_profile_test_same(
+        $trace->events,
+        [
+            'url:' . OpenAiApiOperation::GENERATE_TEXT,
+            'prepare:' . OpenAiApiOperation::GENERATE_TEXT,
+            'authenticate',
+            'transport',
+            'normalize:' . OpenAiApiOperation::GENERATE_TEXT,
+        ]
+    );
+    openai_profile_test_same(
+        $transporter->request instanceof Request ? $transporter->request->getUri() : '',
+        'https://profile.example/v1/responses'
+    );
+    openai_profile_test_same(
+        $transporter->request instanceof Request
+            ? $transporter->request->getHeaderAsString('X-Profile-Prepared')
+            : null,
+        OpenAiApiOperation::GENERATE_TEXT
+    );
+    openai_profile_test_same(
+        $profile->urlCalls,
+        [[
+            'defaultUrl' => 'https://api.openai.com/v1/responses',
+            'path' => 'responses',
+            'operation' => OpenAiApiOperation::GENERATE_TEXT,
+        ]]
+    );
+};
+
+$tests['alternate model catalog parsing and cache isolation'] = static function (): void {
+    openai_profile_test_reset();
+    $traceA = new OpenAiProfileTestTrace();
+    $profileA = new OpenAiProfileTestProfile(
+        'tenant-sensitive-value-alpha',
+        [OpenAiApiOperation::LIST_MODELS],
+        $traceA
+    );
+    $profileA->setParsedModels([
+        openai_profile_test_model_metadata('profile-model', CapabilityEnum::textGeneration()),
+    ]);
+    $authenticationA = new OpenAiProfileTestAuthentication($profileA, $traceA);
+    $directoryA = new OpenAiProfileTestMetadataDirectory();
+    $transporterA = new OpenAiProfileTestTransporter(
+        new Response(200, [], '{"profileModels":true}'),
+        $traceA
+    );
+    $directoryA->setRequestAuthentication($authenticationA);
+    $directoryA->setHttpTransporter($transporterA);
+
+    $models = $directoryA->listModelMetadata();
+    openai_profile_test_same(count($models), 1);
+    openai_profile_test_same($models[0]->getId(), 'profile-model');
+    openai_profile_test_same(
+        $transporterA->request instanceof Request ? $transporterA->request->getUri() : '',
+        'https://profile.example/v1/models'
+    );
+    openai_profile_test_true(in_array('parse-models', $traceA->events, true));
+
+    $traceA2 = new OpenAiProfileTestTrace();
+    $profileA2 = new OpenAiProfileTestProfile(
+        'tenant-sensitive-value-alpha',
+        [OpenAiApiOperation::LIST_MODELS],
+        $traceA2
+    );
+    $directoryA2 = new OpenAiProfileTestMetadataDirectory();
+    $directoryA2->setRequestAuthentication(
+        new OpenAiProfileTestAuthentication($profileA2, $traceA2)
+    );
+
+    $traceB = new OpenAiProfileTestTrace();
+    $profileB = new OpenAiProfileTestProfile(
+        'tenant-sensitive-value-beta',
+        [OpenAiApiOperation::LIST_MODELS],
+        $traceB
+    );
+    $directoryB = new OpenAiProfileTestMetadataDirectory();
+    $directoryB->setRequestAuthentication(
+        new OpenAiProfileTestAuthentication($profileB, $traceB)
+    );
+
+    $directoryStandard = new OpenAiProfileTestMetadataDirectory();
+    $directoryStandard->setRequestAuthentication(new ApiKeyRequestAuthentication('standard-key'));
+
+    openai_profile_test_same($directoryA->baseCacheKey(), $directoryA2->baseCacheKey());
+    openai_profile_test_true($directoryA->baseCacheKey() !== $directoryB->baseCacheKey());
+    openai_profile_test_true($directoryA->baseCacheKey() !== $directoryStandard->baseCacheKey());
+    openai_profile_test_same(
+        strpos($directoryA->baseCacheKey(), 'tenant-sensitive-value-alpha'),
+        false,
+        'Profile cache identity must be hashed before entering the cache key'
+    );
+    openai_profile_test_same(
+        $authenticationA->profileResolutionCount,
+        1,
+        'Catalog cache, request, and parsing must share one pinned profile'
+    );
+};
+
+$tests['unsupported image operation fails before transport'] = static function (): void {
+    openai_profile_test_reset();
+    $trace = new OpenAiProfileTestTrace();
+    $profile = new OpenAiProfileTestProfile(
+        'text-only-profile',
+        [OpenAiApiOperation::LIST_MODELS, OpenAiApiOperation::GENERATE_TEXT],
+        $trace
+    );
+    $transporter = new OpenAiProfileTestTransporter(new Response(200, [], '{}'), $trace);
+    $model = new OpenAiImageGenerationModel(
+        openai_profile_test_model_metadata('image-profile', CapabilityEnum::imageGeneration()),
+        openai_profile_test_provider_metadata()
+    );
+    $authentication = new OpenAiProfileTestAuthentication($profile, $trace);
+    $model->setRequestAuthentication($authentication);
+    $model->setHttpTransporter($transporter);
+
+    $thrown = false;
+    try {
+        $model->generateImageResult(openai_profile_test_prompt());
+    } catch (AiRuntimeException $exception) {
+        $message = $exception->getMessage();
+        $thrown = strpos($message, 'support') !== false
+            && strpos($message, 'image generation') !== false;
+    }
+
+    openai_profile_test_true($thrown, 'Unsupported image generation must throw a runtime exception.');
+    openai_profile_test_same($transporter->sendCount, 0, 'Unsupported operations must not reach transport.');
+    openai_profile_test_same(in_array('authenticate', $trace->events, true), false);
+    openai_profile_test_same($authentication->profileResolutionCount, 1);
+};
+
+$tests['profile-backed image lifecycle uses one pinned profile'] = static function (): void {
+    openai_profile_test_reset();
+    $trace = new OpenAiProfileTestTrace();
+    $profile = new OpenAiProfileTestProfile(
+        'profile-image',
+        [OpenAiApiOperation::GENERATE_IMAGE],
+        $trace
+    );
+    $profile->setNormalizedResponse(
+        openai_profile_test_image_response('normalized-profile-image')
+    );
+    $authentication = new OpenAiProfileTestAuthentication($profile, $trace);
+    $transporter = new OpenAiProfileTestTransporter(
+        new Response(200, ['Content-Type' => 'application/x-profile-image'], '{"image":"raw"}'),
+        $trace
+    );
+    $model = new OpenAiImageGenerationModel(
+        openai_profile_test_model_metadata('gpt-image-profile', CapabilityEnum::imageGeneration()),
+        openai_profile_test_provider_metadata()
+    );
+    $model->setRequestAuthentication($authentication);
+    $model->setHttpTransporter($transporter);
+
+    $result = $model->generateImageResult(openai_profile_test_prompt());
+    openai_profile_test_same($result->getId(), 'img-1234567890');
+    openai_profile_test_same(
+        $result->toFile()->getBase64Data(),
+        base64_encode('normalized-profile-image')
+    );
+    openai_profile_test_same($transporter->sendCount, 1);
+    openai_profile_test_same($authentication->profileResolutionCount, 1);
+    openai_profile_test_same(
+        $trace->events,
+        [
+            'url:' . OpenAiApiOperation::GENERATE_IMAGE,
+            'prepare:' . OpenAiApiOperation::GENERATE_IMAGE,
+            'authenticate',
+            'transport',
+            'normalize:' . OpenAiApiOperation::GENERATE_IMAGE,
+        ]
+    );
+    openai_profile_test_same(
+        $transporter->request instanceof Request ? $transporter->request->getUri() : '',
+        'https://profile.example/v1/images/generations'
+    );
+    openai_profile_test_same(
+        $transporter->request instanceof Request
+            ? $transporter->request->getHeaderAsString('X-Profile-Prepared')
+            : null,
+        OpenAiApiOperation::GENERATE_IMAGE
+    );
+    openai_profile_test_same(
+        $profile->urlCalls,
+        [[
+            'defaultUrl' => 'https://api.openai.com/v1/images/generations',
+            'path' => 'images/generations',
+            'operation' => OpenAiApiOperation::GENERATE_IMAGE,
+        ]]
+    );
+};
+
+$tests['profile cache identity failures fail closed'] = static function (): void {
+    openai_profile_test_reset();
+    $trace = new OpenAiProfileTestTrace();
+    $profile = new OpenAiProfileTestProfile(
+        'must-not-be-shared',
+        [OpenAiApiOperation::LIST_MODELS],
+        $trace
+    );
+    $profile->failCacheKeyLookup();
+    $authentication = new OpenAiProfileTestAuthentication($profile, $trace);
+    $directory = new OpenAiProfileTestMetadataDirectory();
+    $directory->setRequestAuthentication($authentication);
+
+    $thrown = false;
+    try {
+        $directory->baseCacheKey();
+    } catch (\RuntimeException $exception) {
+        $thrown = strpos($exception->getMessage(), 'cache identity') !== false;
+    }
+
+    openai_profile_test_true(
+        $thrown,
+        'A profile cache identity failure must not fall back to a shared cache key'
+    );
+    openai_profile_test_same($authentication->profileResolutionCount, 1);
+};
+
+$tests['resolver filter accepts profiles and rejects invalid values'] = static function (): void {
+    openai_profile_test_reset();
+    $authentication = new ApiKeyRequestAuthentication('filter-test-key');
+    $trace = new OpenAiProfileTestTrace();
+    $filteredProfile = new OpenAiProfileTestProfile(
+        'filtered-profile',
+        [OpenAiApiOperation::GENERATE_TEXT],
+        $trace
+    );
+    $filterSawAuthentication = false;
+    $GLOBALS['openai_profile_test_filters']['ai_provider_for_openai_api_profile'][] =
+        static function (
+            $profile,
+            $receivedAuthentication
+        ) use (
+            $authentication,
+            $filteredProfile,
+            &$filterSawAuthentication
+        ) {
+            openai_profile_test_same($profile, null);
+            $filterSawAuthentication = $receivedAuthentication === $authentication;
+
+            return $filteredProfile;
+        };
+
+    openai_profile_test_same(
+        OpenAiApiProfileResolver::resolve($authentication),
+        $filteredProfile
+    );
+    openai_profile_test_true($filterSawAuthentication, 'The resolver must pass authentication to the filter.');
+
+    openai_profile_test_reset();
+    $GLOBALS['openai_profile_test_filters']['ai_provider_for_openai_api_profile'][] =
+        static function () {
+            return new stdClass();
+        };
+
+    $thrown = false;
+    try {
+        OpenAiApiProfileResolver::resolve($authentication);
+    } catch (AiRuntimeException $exception) {
+        $thrown = strpos($exception->getMessage(), 'OpenAiApiProfileInterface') !== false;
+    }
+    openai_profile_test_true($thrown, 'Invalid filtered profiles must fail validation.');
+};
+
+$failures = [];
+foreach ($tests as $name => $test) {
+    try {
+        $test();
+        fwrite(STDOUT, "PASS {$name}\n");
+    } catch (Throwable $throwable) {
+        $failures[] = $name . ': ' . $throwable->getMessage();
+        fwrite(STDERR, "FAIL {$name}: {$throwable->getMessage()}\n");
+    }
+}
+
+if ($failures !== []) {
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("%d integration profile contract tests passed.\n", count($tests)));

--- a/tests/run.php
+++ b/tests/run.php
@@ -20,6 +20,8 @@ use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\OpenAiAiProvider\Authentication\OpenAiApiProfileRequestAuthenticationAdapter;
 use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileAwareAuthenticationInterface;
 use WordPress\OpenAiAiProvider\Contracts\OpenAiApiProfileInterface;
 use WordPress\OpenAiAiProvider\Metadata\OpenAiModelMetadataDirectory;
@@ -27,6 +29,7 @@ use WordPress\OpenAiAiProvider\Models\OpenAiImageGenerationModel;
 use WordPress\OpenAiAiProvider\Models\OpenAiTextGenerationModel;
 use WordPress\OpenAiAiProvider\Provider\OpenAiApiOperation;
 use WordPress\OpenAiAiProvider\Provider\OpenAiApiProfileResolver;
+use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 /** @var array<string, list<callable>> */
 $GLOBALS['openai_profile_test_filters'] = [];
@@ -230,6 +233,36 @@ final class OpenAiProfileTestAuthentication extends ApiKeyRequestAuthentication 
 }
 
 /**
+ * Profile-aware authentication that is intentionally unrelated to API keys.
+ */
+final class OpenAiProfileTestDelegatedAuthentication implements
+    OpenAiApiProfileAwareAuthenticationInterface
+{
+    private OpenAiApiProfileInterface $profile;
+
+    public function __construct(OpenAiApiProfileInterface $profile)
+    {
+        $this->profile = $profile;
+    }
+
+    public function getOpenAiApiProfile(): OpenAiApiProfileInterface
+    {
+        return $this->profile;
+    }
+
+    public function authenticateRequest(Request $request): Request
+    {
+        return $request->withHeader('Authorization', 'Bearer delegated-profile-token');
+    }
+
+    /** @return array<string, mixed> */
+    public static function getJsonSchema(): array
+    {
+        return ['type' => 'object', 'properties' => []];
+    }
+}
+
+/**
  * Capturing HTTP transporter for request and short-circuit assertions.
  */
 final class OpenAiProfileTestTransporter implements HttpTransporterInterface
@@ -390,6 +423,56 @@ function openai_profile_test_prompt(): array
 
 /** @var array<string, callable> $tests */
 $tests = [];
+
+$tests['profile authentication adapter satisfies the registry type contract'] = static function (): void {
+    openai_profile_test_reset();
+    $profile = new OpenAiProfileTestProfile(
+        'profile-adapter',
+        [OpenAiApiOperation::GENERATE_TEXT],
+        new OpenAiProfileTestTrace()
+    );
+    $delegate = new OpenAiProfileTestDelegatedAuthentication($profile);
+    $authentication = new OpenAiApiProfileRequestAuthenticationAdapter($delegate);
+
+    openai_profile_test_true($authentication instanceof ApiKeyRequestAuthentication);
+    openai_profile_test_same(
+        OpenAiApiProfileResolver::resolve($authentication),
+        $profile
+    );
+
+    $request = new Request(
+        \WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum::GET(),
+        'https://profile-adapter.example/models'
+    );
+    $authenticatedRequest = $authentication->authenticateRequest($request);
+    openai_profile_test_same(
+        $authenticatedRequest->getHeaderAsString('Authorization'),
+        'Bearer delegated-profile-token'
+    );
+    openai_profile_test_same(
+        strpos($authenticatedRequest->getHeaderAsString('Authorization'), 'managed-authentication'),
+        false
+    );
+
+    $registry = new ProviderRegistry();
+    $registry->registerProvider(OpenAiProvider::class);
+    try {
+        $registry->setProviderRequestAuthentication(OpenAiProvider::class, $authentication);
+        openai_profile_test_same(
+            $registry->getProviderRequestAuthentication(OpenAiProvider::class),
+            $authentication
+        );
+        openai_profile_test_same(
+            OpenAiProvider::modelMetadataDirectory()->getRequestAuthentication(),
+            $authentication
+        );
+    } finally {
+        $registry->setProviderRequestAuthentication(
+            OpenAiProvider::class,
+            new ApiKeyRequestAuthentication('profile-adapter-test-reset-key')
+        );
+    }
+};
 
 $tests['plain API-key behavior remains unchanged'] = static function (): void {
     openai_profile_test_reset();


### PR DESCRIPTION
## Summary

This introduces a typed OpenAI API profile layer so integrations can adapt an OpenAI provider request as one coherent unit instead of forking the provider or adding concrete authentication-class checks throughout its models.

The profile contract can control:

- supported operations;
- endpoint URLs;
- request preparation before credentials are attached;
- successful-response normalization before the existing parsers run;
- alternate model-catalog parsing; and
- an isolated model-cache identity.

Profiles can be supplied by a profile-aware request authentication implementation or, in WordPress, through the `ai_provider_for_openai_api_profile` filter.

## Problem

The provider registry can replace the request authentication object, but this provider currently hard-codes the public OpenAI API dialect:

- `api.openai.com/v1` endpoint construction;
- Responses API request and response formats;
- the public `/models` catalog shape;
- image/text operation assumptions; and
- one model metadata cache namespace.

That is sufficient for an API key targeting the public API, but authentication is only one part of integrations that use another OpenAI API profile. A different profile may require a different host, request parameters, response framing, available operations, or model catalog. Today those integrations must patch/fork the provider, duplicate its models, or couple core classes to a concrete authentication implementation.

This is the shared integration primitive needed by the Codex OAuth work discussed in #30. It also provides a more complete foundation for custom OpenAI-compatible profiles discussed in #37.

Related: #30, #37, WordPress/php-ai-client#237.

## Design

### One high-level profile instead of unrelated low-level filters

`OpenAiApiProfileInterface` keeps endpoint, request, response, capability, catalog, and cache behavior together. This avoids combinations such as validating one profile, routing with another, and parsing with a third.

`OpenAiApiProfileAwareAuthenticationInterface` binds the profile to the authentication object whose credentials are valid for that profile. WordPress integrations may use the single resolver filter when application-level composition is preferable.

### Registry compatibility is isolated in one adapter

PHP AI Client 1.3.x currently declares OpenAI authentication as `api_key` and validates every replacement with `instanceof ApiKeyRequestAuthentication`. A profile-aware authenticator that truthfully implements only `RequestAuthenticationInterface` is therefore rejected before the provider's availability and model-metadata objects are rebound.

`OpenAiApiProfileRequestAuthenticationAdapter` centralizes that temporary compatibility requirement. It is an API-key DTO only at the registry boundary and delegates both request authentication and profile selection to the wrapped implementation. Its non-secret marker is never sent. This keeps alternate authentication implementations honest, supports final/third-party authenticators through composition, preserves existing API-key callers, and can be removed when PHP AI Client gains a generic/custom authentication method.

### Lifecycle and ordering

For a bound authentication object, the provider resolves and pins one profile. Text, image, and catalog operations reuse that same instance for their entire lifecycle.

The order is deliberately:

1. build the standard OpenAI request;
2. let the trusted profile choose the URL and prepare the request;
3. apply authentication to that final request;
4. send the request;
5. reject unsuccessful HTTP responses;
6. normalize the successful response; and
7. run the existing result parser.

Authentication therefore sees the final destination/request, while profile normalizers cannot turn an unsuccessful HTTP response into a successful one.

### Cache isolation

The existing API-key cache key is unchanged. Alternate model catalogs append a truncated SHA-256 hash of the profile-provided cache identity. Raw account or tenant identifiers never enter persistent cache keys.

Resolver and cache-identity failures fail closed. There is intentionally no shared "unconfigured" fallback namespace that could mix catalogs from different profiles.

### Security boundary

A profile is trusted plugin/application code because it can choose where an authenticated request is sent. This is documented on the interface, resolver filter, and README. The contract does not expose credentials to the profile; request authentication is applied only after profile request preparation.

Endpoint-specific authenticators can additionally validate the final prepared URI immediately before attaching credentials. The follow-up Codex OAuth implementation does this with an HTTPS host/path allowlist.

## Backward compatibility

When no profile is supplied:

- public OpenAI URLs are unchanged;
- request bodies, headers, and response parsing are unchanged;
- model metadata parsing is unchanged;
- model metadata cache keys are unchanged; and
- existing API-key authentication follows the same path as before.

No existing public class or method signature is removed. The text generation method can remain `final`; extension happens through the profile strategy rather than subclass replacement. The provider continues to advertise the existing API-key authentication method, so PHP AI Client and WordPress connector behavior remain compatible.

## Scope

This PR intentionally contains no OAuth implementation, OpenAI account endpoints, client IDs, token storage, refresh logic, settings UI, or connector overrides. Those concerns can be reviewed separately after this neutral integration contract lands.

## Validation

`composer lint` passes, including:

- PHPCS / PHP 7.4 compatibility;
- PHPStan at max level; and
- eight standalone profile contract tests.

The tests verify:

- a pure profile-aware authenticator passes the real `ProviderRegistry` type check through the adapter and is fully rebound into the metadata directory;
- the adapter delegates authentication and never sends its compatibility marker;
- unchanged API-key routing and authentication behavior;
- profile request preparation happens before authentication;
- successful response normalization happens before existing parsing;
- alternate model-catalog parsing and hashed cache isolation;
- one pinned profile instance across request/cache/response stages;
- unsupported image operations stop before authentication/transport;
- successful profile-backed image lifecycle;
- cache identity failures fail closed; and
- resolver filter validation.

The adapter regression was also derived from a live WordPress 7 / PHP AI Client 1.3.1 runtime check, which exposed the concrete registry validation that an `instanceof`-free unit path would otherwise miss.
