### PR TITLE
Add WordPress Playground preview blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/options-connectors.php",
+	"preferredVersions": {
+		"php": "8.1",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "ai"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "ai-provider-for-openai"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php update_option( 'wpai_features_enabled', true ); update_option( 'wpai_feature_image-generation_enabled', true );"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- add a WordPress Playground blueprint under `.wordpress-org/blueprints/`
- install and activate both the AI plugin and this provider
- enable the global AI feature flag and image generation, then open the Connectors screen
- enable Playground networking so the provider can reach the OpenAI API after the user configures credentials

## Validation

- blueprint validates against the current Playground JSON schema
- `composer lint`
- `composer test` (45 tests, 207 assertions; 1 skipped)

This supplies the repository-side blueprint requested in #45. A WordPress.org committer will still need to deploy the asset and enable the public preview there.

Refs #45