### PR TITLE
Fix provider logo path for symlinked installations

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -27,6 +27,14 @@ if (!defined('ABSPATH')) {
     return;
 }
 
+// Preserve the path beneath WP_PLUGIN_DIR when WordPress loads the plugin through a symlink.
+if (!defined('AI_PROVIDER_FOR_OPENAI_PLUGIN_DIR')) {
+    define(
+        'AI_PROVIDER_FOR_OPENAI_PLUGIN_DIR',
+        WP_PLUGIN_DIR . '/' . dirname(plugin_basename(__FILE__))
+    );
+}
+
 require_once __DIR__ . '/src/autoload.php';
 
 /**

--- a/src/Provider/OpenAiProvider.php
+++ b/src/Provider/OpenAiProvider.php
@@ -99,7 +99,14 @@ class OpenAiProvider extends AbstractApiProvider
         }
         // Provider logoPath support was added in 1.3.0.
         if (version_compare(AiClient::VERSION, '1.3.0', '>=')) {
-            $providerMetadataArgs[] = dirname(__DIR__, 2) . '/assets/images/openai.svg';
+            $pluginDir = dirname(__DIR__, 2);
+            if (defined('AI_PROVIDER_FOR_OPENAI_PLUGIN_DIR')) {
+                $definedPluginDir = constant('AI_PROVIDER_FOR_OPENAI_PLUGIN_DIR');
+                if (is_string($definedPluginDir)) {
+                    $pluginDir = $definedPluginDir;
+                }
+            }
+            $providerMetadataArgs[] = $pluginDir . '/assets/images/openai.svg';
         }
         return new ProviderMetadata(...$providerMetadataArgs);
     }

--- a/tests/OpenAiProviderTest.php
+++ b/tests/OpenAiProviderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+
+class OpenAiProviderTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testProviderLogoUsesWordPressPluginDirectory(): void
+    {
+        $pluginDir = '/wordpress/wp-content/plugins/ai-provider-for-openai';
+        define('AI_PROVIDER_FOR_OPENAI_PLUGIN_DIR', $pluginDir);
+
+        $metadata = OpenAiProvider::metadata();
+
+        $this->assertSame(
+            $pluginDir . '/assets/images/openai.svg',
+            $metadata->getLogoPath()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

use `plugin_basename(__FILE__)` to get the path for the icon.

## Problem

WordPress 7 validates provider logo paths before exposing AI providers as connectors. Using `__DIR__` resolves to an external symlink target, causing `_wp_connectors_resolve_ai_provider_logo_url()` to reject an otherwise valid plugin asset and emit a doing-it-wrong notice.

So if the plugin is symlinked to wp-content/plugins users will see this notice:
Notice: Function _wp_connectors_resolve_ai_provider_logo_url was called incorrectly. Provider logo path must be located within the plugins or must-use plugins directory. Please see Debugging in WordPress for more information. (This message was added in version 7.0.0.) in /home/dave/Git/wordpress/wp-includes/functions.php on line 6260


## Testing

- WordPress resolver integration check with a symlinked plugin: path remained inside `WP_PLUGIN_DIR`, asset existed, and URL resolution succeeded without a notice