### PR TITLE
Support deferred tool loading through annotations and provider policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Available models are dynamically discovered from the OpenAI API. This includes G
 ## Automatic hosted tool search (experimental)
 
 When more than **10 application functions** are declared, this provider enables
-OpenAI-hosted tool search and defers their parameter schemas. No new prompt-builder
-method or per-function flag is needed:
+OpenAI-hosted tool search on eligible requests and defers their parameter schemas.
+No new prompt-builder method is needed:
 
 ```php
 // $functions is an ordinary list of SDK FunctionDeclaration objects.
@@ -79,25 +79,36 @@ $result = AiClient::prompt('Find the relevant content')
 ```
 
 The initial model allowlist is `gpt-5.4`, `gpt-5.4-pro`, and their dated snapshots.
-Other models retain eager loading, even if their names look newer. The optimization
-also requires the generic `ProviderData` message support proposed in
-[php-ai-client #282](https://github.com/WordPress/php-ai-client/pull/282).
-Older SDK versions continue to work with eager tools. This development branch uses
-that SDK PR as a **development-only** dependency for tests/static analysis; replace
-the branch constraint with a released version once the SDK change is available.
+Other models retain eager loading, even if their names look newer. This experiment
+uses **OpenAI-managed conversation state**, not stateless message replay. Requests
+with `store: false`, replayed model messages/reasoning, or function results without
+a `previous_response_id` keep functions eager. The provider never changes `store`
+or manages response IDs on the application's behalf.
 
 Web search is independent and does not count toward the threshold. Explicit
 `tool_choice` values other than `auto` keep functions eager so that forced or
 restricted tool choice does not accidentally become a discovery call.
 
-### Adjusting or disabling the policy
+### Function annotations and request options
 
-Use existing model configuration, not a new core API:
+Generic function metadata can opt individual functions in or keep them eager:
+
+```php
+$weather = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
+    'get_weather',
+    'Gets the weather',
+    null,
+    ['deferredLoading' => true]
+);
+```
+
+Use existing model configuration for the request-wide default:
 
 ```php
 $config = new \WordPress\AiClient\Providers\Models\DTO\ModelConfig();
-$config->setCustomOption('openai_tool_search_threshold', 20); // Enable above 20 functions.
-// $config->setCustomOption('openai_tool_search_threshold', false); // Disable.
+$config->setCustomOptions(['deferredLoading' => true]);
+// $config->setCustomOptions(['deferredLoading' => false]); // Disable the optimization.
+// $config->setCustomOption('openai_tool_search_threshold', 20); // Tune automatic activation.
 
 $result = AiClient::prompt('Find the relevant content')
     ->usingModel(OpenAiProvider::model('gpt-5.4'))
@@ -106,23 +117,61 @@ $result = AiClient::prompt('Find the relevant content')
     ->generateTextResult();
 ```
 
-The threshold accepts a non-negative integer or `false`. `0` enables search for any
-non-empty function list on an eligible model. This provider-only option is consumed
-locally and never sent to OpenAI. Other custom options retain their existing behavior.
+Precedence on an eligible model/request:
+
+1. Request `deferredLoading: false` or threshold `false` disables all deferral,
+   including per-function opt-ins.
+2. Per-function `deferredLoading: false` keeps that function eager;
+   `true` makes it searchable even below the threshold.
+3. Unannotated functions use request `deferredLoading: true`, if set; otherwise
+   they are deferred only when the function count exceeds the threshold (default 10).
+
+The threshold accepts a non-negative integer or `false`. `0` defers any non-empty
+inventory unless an individual function opts out. Search is added only if at least
+one function is deferred. `deferredLoading` values must be booleans. Unknown metadata
+is ignored, not copied into OpenAI tools or parameter schemas. Both policy options
+are consumed locally and never sent to OpenAI.
+
+Per-function annotations require the generic `FunctionDeclaration::getMetadata()`
+extension in [php-ai-client #282](https://github.com/WordPress/php-ai-client/pull/282).
+Automatic and request-level policy also work on older SDKs without that accessor.
+This development branch follows the SDK PR as a **development-only** dependency to
+test annotations; replace its branch constraint with a released version before
+releasing this experiment. No new core message types or model options are required.
 
 ### Conversation history and execution
 
 Hosted search runs at OpenAI; applications execute only ordinary returned function
-calls, never `tool_search_call`. Preserve **all** returned messages and parts (use
-`$result->toMessages()` for history) when continuing a conversation. The provider
-round-trips search call/output items, reasoning, and function-call namespace metadata
-through SDK array/JSON serialization. It validates ownership and supported item shapes
-before replay. Client-executed discovery is not supported by this experiment.
+calls, never `tool_search_call`. OpenAI retains search results and namespace data.
+The provider validates hosted search output, exposes the response ID as usual, and
+sets `$result->getAdditionalData()['tool_search']['continuation']` to
+`previous_response_id` when search was used. Discovery items are **not** retained by
+`toMessages()` or serialized message history. Client-executed discovery is rejected.
 
-For `store: false`, retain reasoning encrypted content where needed through the
-existing `include: ['reasoning.encrypted_content']` custom option. Alternatively,
-use `previous_response_id` with only new input; do not also replay the already-stored
-history. The provider does not infer or cache response IDs on your behalf.
+Continue with the existing custom option and **only new input or function results**:
+
+```php
+$config->setCustomOption('previous_response_id', $result->getId());
+
+// $functionResponse contains the authorized function's result and its call ID.
+$nextResult = AiClient::prompt()
+    ->withFunctionResponse($functionResponse)
+    ->usingModel(OpenAiProvider::model('gpt-5.4'))
+    ->usingModelConfig($config)
+    ->usingFunctionDeclarations(...$functions)
+    ->generateTextResult();
+```
+
+Do not include the previous model response or reasoning in this request: the server
+already has it. Keep passing current declarations for name mapping and discovery.
+Use the latest response ID on each subsequent turn. A search-only response carries
+an empty candidate (no executable function) and the continuation hint; applications
+can inspect it and decide whether to continue within their existing turn budget.
+An application with a no-storage policy must keep `store: false` and eager loading.
+
+The eager fallback prevents new discovery in stateless requests; it cannot reconstruct
+discovery context from an earlier searched response. Once search has been used,
+continue that conversation through its response ID, or start a new conversation.
 
 Tool discovery is not authorization. Validate tool names, arguments, permissions,
 and approvals against the application's current tool registry before executing them,
@@ -147,7 +196,8 @@ on the same tasks at 10, 11, 20, and 50 functions, including small and large sch
 Measure task success, wrong/missed tool selections, total input/output tokens, cache
 hits, and end-to-end latency across multiple turns. Hosted search can add latency and
 extra model work; keep an opt-out and collect evidence before generalizing the policy.
-Unit tests verify wire construction and replay, not real-world quality or savings.
+Unit tests verify wire construction and server-continuation plumbing, not real-world
+quality or savings. Stateless replay of discovery remains outside this experiment.
 This model currently exposes non-streaming generation; streaming support is outside
 this change.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,93 @@ echo $result->toText();
 
 Available models are dynamically discovered from the OpenAI API. This includes GPT models for text generation, DALL-E and GPT Image models for image generation, and TTS models for text-to-speech. See the [OpenAI documentation](https://platform.openai.com/docs/models) for the full list of available models.
 
+## Automatic hosted tool search (experimental)
+
+When more than **10 application functions** are declared, this provider enables
+OpenAI-hosted tool search and defers their parameter schemas. No new prompt-builder
+method or per-function flag is needed:
+
+```php
+// $functions is an ordinary list of SDK FunctionDeclaration objects.
+$result = AiClient::prompt('Find the relevant content')
+    ->usingModel(OpenAiProvider::model('gpt-5.4'))
+    ->usingFunctionDeclarations(...$functions)
+    ->generateTextResult();
+```
+
+The initial model allowlist is `gpt-5.4`, `gpt-5.4-pro`, and their dated snapshots.
+Other models retain eager loading, even if their names look newer. The optimization
+also requires the generic `ProviderData` message support proposed in
+[php-ai-client #282](https://github.com/WordPress/php-ai-client/pull/282).
+Older SDK versions continue to work with eager tools. This development branch uses
+that SDK PR as a **development-only** dependency for tests/static analysis; replace
+the branch constraint with a released version once the SDK change is available.
+
+Web search is independent and does not count toward the threshold. Explicit
+`tool_choice` values other than `auto` keep functions eager so that forced or
+restricted tool choice does not accidentally become a discovery call.
+
+### Adjusting or disabling the policy
+
+Use existing model configuration, not a new core API:
+
+```php
+$config = new \WordPress\AiClient\Providers\Models\DTO\ModelConfig();
+$config->setCustomOption('openai_tool_search_threshold', 20); // Enable above 20 functions.
+// $config->setCustomOption('openai_tool_search_threshold', false); // Disable.
+
+$result = AiClient::prompt('Find the relevant content')
+    ->usingModel(OpenAiProvider::model('gpt-5.4'))
+    ->usingModelConfig($config)
+    ->usingFunctionDeclarations(...$functions)
+    ->generateTextResult();
+```
+
+The threshold accepts a non-negative integer or `false`. `0` enables search for any
+non-empty function list on an eligible model. This provider-only option is consumed
+locally and never sent to OpenAI. Other custom options retain their existing behavior.
+
+### Conversation history and execution
+
+Hosted search runs at OpenAI; applications execute only ordinary returned function
+calls, never `tool_search_call`. Preserve **all** returned messages and parts (use
+`$result->toMessages()` for history) when continuing a conversation. The provider
+round-trips search call/output items, reasoning, and function-call namespace metadata
+through SDK array/JSON serialization. It validates ownership and supported item shapes
+before replay. Client-executed discovery is not supported by this experiment.
+
+For `store: false`, retain reasoning encrypted content where needed through the
+existing `include: ['reasoning.encrypted_content']` custom option. Alternatively,
+use `previous_response_id` with only new input; do not also replay the already-stored
+history. The provider does not infer or cache response IDs on your behalf.
+
+Tool discovery is not authorization. Validate tool names, arguments, permissions,
+and approvals against the application's current tool registry before executing them,
+especially when replaying history containing previously loaded tools.
+
+### Evidence and limitations
+
+- [OpenAI](https://developers.openai.com/api/docs/guides/tools-tool-search) documents
+  hosted search for GPT-5.4 and later compatible Responses models. Deferred flat
+  functions still expose their names/descriptions; the main saving is parameter
+  schemas, not request-upload size. Namespaces can save more but require meaningful
+  grouping metadata, so this provider does not invent them.
+- [Vercel AI SDK v7](https://ai-sdk.dev/providers/ai-sdk-providers/openai) exposes
+  `openai.tools.toolSearch()` and per-tool `providerOptions.openai.deferLoading`.
+  Its documented API is explicit rather than count-triggered.
+- [Vercel's Anthropic provider](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic)
+  similarly uses provider-defined search and deferred-loading options.
+
+Research checked 2026-09-09. The `>10` threshold is a tunable experiment, not an OpenAI
+requirement or a measured performance guarantee. Compare eager vs automatic behavior
+on the same tasks at 10, 11, 20, and 50 functions, including small and large schemas.
+Measure task success, wrong/missed tool selections, total input/output tokens, cache
+hits, and end-to-end latency across multiple turns. Hosted search can add latency and
+extra model work; keep an opt-out and collect evidence before generalizing the policy.
+Unit tests verify wire construction and replay, not real-world quality or savings.
+This model currently exposes non-streaming generation; streaming support is outside
+this change.
+
 ## Configuration
 
 The provider uses the `OPENAI_API_KEY` environment variable for authentication. You can set this in your environment or via PHP:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.6",
         "slevomat/coding-standard": "^8.20",
         "squizlabs/php_codesniffer": "^3.7 || ^4.0",
-        "wordpress/php-ai-client": "^1.3.1"
+        "wordpress/php-ai-client": "dev-feature/gh281-deferred-tool-loading"
     },
     "suggest": {
         "wordpress/php-ai-client": "Required. The core PHP AI Client SDK that this provider extends."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4e9d44c42b4564b6704546b4b565849",
+    "content-hash": "654857e55287501592d039ec10b9cda9",
     "packages": [],
     "packages-dev": [
         {
@@ -767,16 +767,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -856,7 +856,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -2711,19 +2711,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
                 "shasum": ""
             },
             "require": {
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
@@ -2731,6 +2732,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
             },
             "bin": [
                 "bin/phpcbf",
@@ -2786,7 +2791,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-10T16:43:36+00:00"
+            "time": "2026-08-06T02:45:27+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2840,16 +2845,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "1.4.0",
+            "version": "dev-feature/gh281-deferred-tool-loading",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client",
-                "reference": "a31b0ec6d4676d4a464055fef72173e2d8995214"
+                "reference": "2f88b1a54c486dbed8bbd9c887dc61f25b61f481"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/a31b0ec6d4676d4a464055fef72173e2d8995214",
-                "reference": "a31b0ec6d4676d4a464055fef72173e2d8995214",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/2f88b1a54c486dbed8bbd9c887dc61f25b61f481",
+                "reference": "2f88b1a54c486dbed8bbd9c887dc61f25b61f481",
                 "shasum": ""
             },
             "require": {
@@ -2875,14 +2880,14 @@
                 "slevomat/coding-standard": "^8.20",
                 "squizlabs/php_codesniffer": "^3.7 || ^4.0",
                 "symfony/dotenv": "^5.4",
-                "wordpress/anthropic-ai-provider": "^1.0",
-                "wordpress/google-ai-provider": "^1.0",
-                "wordpress/openai-ai-provider": "^1.0"
+                "wordpress/ai-provider-for-anthropic": "^1.0",
+                "wordpress/ai-provider-for-google": "^1.0",
+                "wordpress/ai-provider-for-openai": "^1.0"
             },
             "suggest": {
-                "wordpress/anthropic-ai-provider": "For Anthropic Claude model support",
-                "wordpress/google-ai-provider": "For Google Gemini model support",
-                "wordpress/openai-ai-provider": "For OpenAI GPT model support"
+                "wordpress/ai-provider-for-anthropic": "For Anthropic Claude model support",
+                "wordpress/ai-provider-for-google": "For Google Gemini model support",
+                "wordpress/ai-provider-for-openai": "For OpenAI GPT model support"
             },
             "type": "library",
             "autoload": {
@@ -2914,13 +2919,14 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-07-15T01:43:23+00:00"
+            "time": "2026-09-09T18:36:40+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "phpcompatibility/php-compatibility": 20
+        "phpcompatibility/php-compatibility": 20,
+        "wordpress/php-ai-client": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -2849,12 +2849,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client",
-                "reference": "2f88b1a54c486dbed8bbd9c887dc61f25b61f481"
+                "reference": "dec7664cc17d8cf4287680c564fcdc428ebce7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/2f88b1a54c486dbed8bbd9c887dc61f25b61f481",
-                "reference": "2f88b1a54c486dbed8bbd9c887dc61f25b61f481",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/dec7664cc17d8cf4287680c564fcdc428ebce7ec",
+                "reference": "dec7664cc17d8cf4287680c564fcdc428ebce7ec",
                 "shasum": ""
             },
             "require": {
@@ -2919,7 +2919,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-09-09T18:36:40+00:00"
+            "time": "2026-09-09T19:05:01+00:00"
         }
     ],
     "aliases": [],

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -9,7 +9,6 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\DTO\ProviderData;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
@@ -81,11 +80,6 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
      * @var array<string, string>
      */
     private array $clientFunctionNameMap = [];
-
-    /**
-     * @var array<string, string> Provider namespaces keyed by function call ID for replay.
-     */
-    private array $functionCallNamespaces = [];
 
     private const OPENAI_FUNCTION_NAME_MAX_LENGTH = 64;
     private const OPENAI_FUNCTION_NAME_HASH_LENGTH = 8;
@@ -186,13 +180,25 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $customOptions = $config->getCustomOptions();
 
         // Provider policy, not an OpenAI wire parameter or a core model requirement.
-        unset($customOptions['openai_tool_search_threshold']);
+        unset($customOptions['openai_tool_search_threshold'], $customOptions['deferredLoading']);
 
         if (is_array($functionDeclarations) || $webSearch) {
             $params['tools'] = $this->prepareToolsParam(
                 $functionDeclarations,
                 $webSearch
             );
+            if (!$this->supportsToolSearchInput($params['input'])) {
+                // Stateless history cannot retain discovery items with the current SDK message types.
+                $tools = [];
+                foreach ($params['tools'] as $tool) {
+                    if ($tool['type'] === 'tool_search') {
+                        continue;
+                    }
+                    unset($tool['defer_loading']);
+                    $tools[] = $tool;
+                }
+                $params['tools'] = $tools;
+            }
         }
 
         /*
@@ -281,49 +287,15 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     protected function prepareInputParam(array $messages): array
     {
         $this->validateMessages($messages);
-        $this->functionCallNamespaces = [];
 
         $input = [];
         foreach ($messages as $message) {
-            $contentParts = [];
-            foreach ($message->getParts() as $part) {
-                $providerData = method_exists($part, 'getProviderData') ? $part->getProviderData() : null;
-                if ($providerData !== null || $part->getChannel()->isThought()) {
-                    // Flush content before each top-level item to preserve the original order.
-                    $contentItem = $this->getMessageInputItem(new Message($message->getRole(), $contentParts));
-                    if ($contentItem !== null) {
-                        $input[] = $contentItem;
-                    }
-                    $contentParts = [];
-                    if ($providerData !== null) {
-                        if ($providerData->getProviderId() !== $this->providerMetadata()->getId()) {
-                            throw new InvalidArgumentException('Cannot replay message data from another provider.');
-                        }
-                        if (!$message->getRole()->isModel()) {
-                            throw new InvalidArgumentException('Tool search data must belong to a model message.');
-                        }
-                        $item = $providerData->getData();
-                        if (($item['type'] ?? null) === 'function_call_namespace') {
-                            if (!is_string($item['call_id'] ?? null) || !is_string($item['namespace'] ?? null)) {
-                                throw new InvalidArgumentException('Invalid function call namespace data.');
-                            }
-                            $this->functionCallNamespaces[$item['call_id']] = $item['namespace'];
-                            continue;
-                        }
-                        $this->validateToolSearchItem($item);
-                        $input[] = $item;
-                    } else {
-                        foreach ($this->getReasoningInputItems(new Message($message->getRole(), [$part])) as $item) {
-                            $input[] = $item;
-                        }
-                    }
-                } else {
-                    $contentParts[] = $part;
-                }
+            foreach ($this->getReasoningInputItems($message) as $reasoningItem) {
+                $input[] = $reasoningItem;
             }
-            $contentItem = $this->getMessageInputItem(new Message($message->getRole(), $contentParts));
-            if ($contentItem !== null) {
-                $input[] = $contentItem;
+            $inputItem = $this->getMessageInputItem($message);
+            if ($inputItem !== null) {
+                $input[] = $inputItem;
             }
         }
         return $input;
@@ -397,10 +369,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         foreach ($messages as $message) {
             $contentParts = [];
             foreach ($message->getParts() as $part) {
-                if (
-                    $part->getChannel()->isThought()
-                    || (method_exists($part, 'getProviderData') && $part->getProviderData() !== null)
-                ) {
+                if ($part->getChannel()->isThought()) {
                     continue;
                 }
                 $contentParts[] = $part;
@@ -569,17 +538,12 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                     'The function_call typed message part must contain a function name.'
                 );
             }
-            $data = [
+            return [
                 'type' => 'function_call',
                 'call_id' => $functionCall->getId(),
                 'name' => $this->openAiFunctionName($functionName),
                 'arguments' => json_encode($functionCall->getArgs()),
             ];
-            $callId = $functionCall->getId();
-            if ($callId !== null && isset($this->functionCallNamespaces[$callId])) {
-                $data['namespace'] = $this->functionCallNamespaces[$callId];
-            }
-            return $data;
         }
         if ($type->isFunctionResponse()) {
             $functionResponse = $part->getFunctionResponse();
@@ -618,7 +582,9 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $tools = [];
         $this->openAiFunctionNameMap = [];
         $this->clientFunctionNameMap = [];
-        $useToolSearch = $this->shouldUseToolSearch(count($functionDeclarations ?? []));
+        $deferByDefault = $this->shouldUseToolSearch(count($functionDeclarations ?? []));
+        $canDefer = $this->supportsToolSearch();
+        $useToolSearch = false;
 
         if (is_array($functionDeclarations)) {
             foreach ($functionDeclarations as $functionDeclaration) {
@@ -629,8 +595,15 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                     'description' => $functionDeclaration->getDescription(),
                     'parameters' => $functionDeclaration->getParameters(),
                 ];
-                if ($useToolSearch) {
+                // Older SDKs can still use request-level policy without per-function annotations.
+                $metadata = method_exists($functionDeclaration, 'getMetadata')
+                    ? $functionDeclaration->getMetadata() : [];
+                if (array_key_exists('deferredLoading', $metadata) && !is_bool($metadata['deferredLoading'])) {
+                    throw new InvalidArgumentException('Function metadata deferredLoading must be a boolean.');
+                }
+                if ($canDefer && ($metadata['deferredLoading'] ?? $deferByDefault)) {
                     $tool['defer_loading'] = true;
+                    $useToolSearch = true;
                 }
                 $tools[] = $tool;
             }
@@ -664,16 +637,34 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     protected function shouldUseToolSearch(int $functionCount): bool
     {
         $options = $this->getConfig()->getCustomOptions();
-        $threshold = $options['openai_tool_search_threshold'] ?? 10;
+        $threshold = array_key_exists('openai_tool_search_threshold', $options)
+            ? $options['openai_tool_search_threshold'] : 10;
         if ($threshold !== false && (!is_int($threshold) || $threshold < 0)) {
             throw new InvalidArgumentException('openai_tool_search_threshold must be a non-negative integer or false.');
         }
+        if (array_key_exists('deferredLoading', $options) && !is_bool($options['deferredLoading'])) {
+            throw new InvalidArgumentException('The deferredLoading custom option must be a boolean.');
+        }
 
-        // Explicit tool choice must keep its original meaning, including forced function calls.
+        return $this->supportsToolSearch()
+            && (($options['deferredLoading'] ?? false) || ($threshold !== false && $functionCount > $threshold));
+    }
+
+    /**
+     * Checks whether the model and request options allow the hosted-search experiment.
+     *
+     * @since n.e.x.t
+     *
+     * @return bool Whether deferred tools can be used.
+     */
+    protected function supportsToolSearch(): bool
+    {
+        $options = $this->getConfig()->getCustomOptions();
         if (
-            $threshold === false || $functionCount <= $threshold
+            ($options['deferredLoading'] ?? null) === false
+            || ($options['openai_tool_search_threshold'] ?? null) === false
+            || ($options['store'] ?? true) === false
             || (isset($options['tool_choice']) && $options['tool_choice'] !== 'auto')
-            || !class_exists(ProviderData::class)
         ) {
             return false;
         }
@@ -682,7 +673,32 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     }
 
     /**
-     * Validates an opaque hosted search item before preserving or replaying it.
+     * Checks that input is new user content or tool results for a stored response.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<array<string, mixed>> $input The prepared input items.
+     * @return bool Whether discovery state can remain on the server instead of being replayed.
+     */
+    protected function supportsToolSearchInput(array $input): bool
+    {
+        $options = $this->getConfig()->getCustomOptions();
+        $previousId = $options['previous_response_id'] ?? null;
+        foreach ($input as $item) {
+            if (
+                ($item['role'] ?? null) === 'assistant'
+                || in_array($item['type'] ?? null, ['reasoning', 'function_call'], true)
+                || (($item['type'] ?? null) === 'function_call_output'
+                    && (!is_string($previousId) || $previousId === ''))
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Validates hosted search output without representing it as an application function call.
      *
      * @since n.e.x.t
      *
@@ -701,7 +717,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             || ($type === 'tool_search_call' && !is_array($item['arguments'] ?? null))
             || ($type === 'tool_search_output' && !is_array($item['tools'] ?? null))
         ) {
-            throw new InvalidArgumentException('Only completed hosted tool search items can be replayed.');
+            throw new InvalidArgumentException('Only completed hosted tool search items are supported.');
         }
     }
 
@@ -750,6 +766,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         $candidates = [];
         $pendingReasoningParts = [];
+        $toolSearchUsed = false;
         foreach ($responseData['output'] as $index => $outputItem) {
             if (!is_array($outputItem) || array_is_list($outputItem)) {
                 throw ResponseException::fromInvalidData(
@@ -768,9 +785,6 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             }
 
             if (in_array($outputItem['type'] ?? '', ['tool_search_call', 'tool_search_output'], true)) {
-                if (!class_exists(ProviderData::class)) {
-                    throw new RuntimeException('Tool search requires SDK support for provider message data.');
-                }
                 try {
                     $this->validateToolSearchItem($outputItem);
                 } catch (InvalidArgumentException $e) {
@@ -780,9 +794,8 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                         $e->getMessage()
                     );
                 }
-                $pendingReasoningParts[] = new MessagePart(
-                    new ProviderData($this->providerMetadata()->getId(), $outputItem)
-                );
+                // OpenAI retains these items for previous_response_id continuation.
+                $toolSearchUsed = true;
                 continue;
             }
 
@@ -794,27 +807,8 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             );
             if ($candidate !== null) {
                 $candidates[] = $candidate;
-            } elseif ($pendingReasoningParts !== [] && class_exists(ProviderData::class)) {
-                // Do not lose discovery state when an unrelated built-in item intervenes.
-                foreach ($pendingReasoningParts as $part) {
-                    if ($part->getProviderData() !== null) {
-                        $candidates[] = new Candidate(
-                            new Message(MessageRoleEnum::model(), $pendingReasoningParts),
-                            $this->parseStatusToFinishReason($status, false)
-                        );
-                        break;
-                    }
-                }
             }
             $pendingReasoningParts = [];
-        }
-
-        // A search-only response still carries conversation state, not an application tool call.
-        if ($pendingReasoningParts !== []) {
-            $candidates[] = new Candidate(
-                new Message(MessageRoleEnum::model(), $pendingReasoningParts),
-                $this->parseStatusToFinishReason($status, false)
-            );
         }
 
         $id = isset($responseData['id']) && is_string($responseData['id']) ? $responseData['id'] : '';
@@ -829,6 +823,19 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         // Use any other data from the response as provider-specific response metadata.
         $additionalData = $responseData;
         unset($additionalData['id'], $additionalData['output'], $additionalData['usage']);
+        if ($toolSearchUsed) {
+            if ($id === '') {
+                throw ResponseException::fromMissingData($this->providerMetadata()->getName(), 'id');
+            }
+            $additionalData['tool_search'] = ['continuation' => 'previous_response_id'];
+            if ($candidates === []) {
+                // The SDK requires a candidate, but hosted discovery is not an executable function call.
+                $candidates[] = new Candidate(
+                    new Message(MessageRoleEnum::model(), []),
+                    $this->parseStatusToFinishReason($status, false)
+                );
+            }
+        }
 
         return new GenerativeAiResult(
             $id,
@@ -1041,16 +1048,6 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         $part = new MessagePart($functionCall);
         $parts = $reasoningParts;
-        if (isset($outputItem['namespace']) && is_string($outputItem['namespace'])) {
-            if (!class_exists(ProviderData::class)) {
-                throw new RuntimeException('Namespaced function calls require SDK support for provider message data.');
-            }
-            $parts[] = new MessagePart(new ProviderData($this->providerMetadata()->getId(), [
-                'type' => 'function_call_namespace',
-                'call_id' => $outputItem['call_id'],
-                'namespace' => $outputItem['namespace'],
-            ]));
-        }
         $parts[] = $part;
         $message = new Message(MessageRoleEnum::model(), $parts);
 

--- a/src/Models/OpenAiTextGenerationModel.php
+++ b/src/Models/OpenAiTextGenerationModel.php
@@ -9,6 +9,7 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ProviderData;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
@@ -80,6 +81,11 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
      * @var array<string, string>
      */
     private array $clientFunctionNameMap = [];
+
+    /**
+     * @var array<string, string> Provider namespaces keyed by function call ID for replay.
+     */
+    private array $functionCallNamespaces = [];
 
     private const OPENAI_FUNCTION_NAME_MAX_LENGTH = 64;
     private const OPENAI_FUNCTION_NAME_HASH_LENGTH = 8;
@@ -179,6 +185,9 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $webSearch = $config->getWebSearch();
         $customOptions = $config->getCustomOptions();
 
+        // Provider policy, not an OpenAI wire parameter or a core model requirement.
+        unset($customOptions['openai_tool_search_threshold']);
+
         if (is_array($functionDeclarations) || $webSearch) {
             $params['tools'] = $this->prepareToolsParam(
                 $functionDeclarations,
@@ -272,15 +281,49 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
     protected function prepareInputParam(array $messages): array
     {
         $this->validateMessages($messages);
+        $this->functionCallNamespaces = [];
 
         $input = [];
         foreach ($messages as $message) {
-            foreach ($this->getReasoningInputItems($message) as $reasoningItem) {
-                $input[] = $reasoningItem;
+            $contentParts = [];
+            foreach ($message->getParts() as $part) {
+                $providerData = method_exists($part, 'getProviderData') ? $part->getProviderData() : null;
+                if ($providerData !== null || $part->getChannel()->isThought()) {
+                    // Flush content before each top-level item to preserve the original order.
+                    $contentItem = $this->getMessageInputItem(new Message($message->getRole(), $contentParts));
+                    if ($contentItem !== null) {
+                        $input[] = $contentItem;
+                    }
+                    $contentParts = [];
+                    if ($providerData !== null) {
+                        if ($providerData->getProviderId() !== $this->providerMetadata()->getId()) {
+                            throw new InvalidArgumentException('Cannot replay message data from another provider.');
+                        }
+                        if (!$message->getRole()->isModel()) {
+                            throw new InvalidArgumentException('Tool search data must belong to a model message.');
+                        }
+                        $item = $providerData->getData();
+                        if (($item['type'] ?? null) === 'function_call_namespace') {
+                            if (!is_string($item['call_id'] ?? null) || !is_string($item['namespace'] ?? null)) {
+                                throw new InvalidArgumentException('Invalid function call namespace data.');
+                            }
+                            $this->functionCallNamespaces[$item['call_id']] = $item['namespace'];
+                            continue;
+                        }
+                        $this->validateToolSearchItem($item);
+                        $input[] = $item;
+                    } else {
+                        foreach ($this->getReasoningInputItems(new Message($message->getRole(), [$part])) as $item) {
+                            $input[] = $item;
+                        }
+                    }
+                } else {
+                    $contentParts[] = $part;
+                }
             }
-            $inputItem = $this->getMessageInputItem($message);
-            if ($inputItem !== null) {
-                $input[] = $inputItem;
+            $contentItem = $this->getMessageInputItem(new Message($message->getRole(), $contentParts));
+            if ($contentItem !== null) {
+                $input[] = $contentItem;
             }
         }
         return $input;
@@ -354,7 +397,10 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         foreach ($messages as $message) {
             $contentParts = [];
             foreach ($message->getParts() as $part) {
-                if ($part->getChannel()->isThought()) {
+                if (
+                    $part->getChannel()->isThought()
+                    || (method_exists($part, 'getProviderData') && $part->getProviderData() !== null)
+                ) {
                     continue;
                 }
                 $contentParts[] = $part;
@@ -523,12 +569,17 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                     'The function_call typed message part must contain a function name.'
                 );
             }
-            return [
+            $data = [
                 'type' => 'function_call',
                 'call_id' => $functionCall->getId(),
                 'name' => $this->openAiFunctionName($functionName),
                 'arguments' => json_encode($functionCall->getArgs()),
             ];
+            $callId = $functionCall->getId();
+            if ($callId !== null && isset($this->functionCallNamespaces[$callId])) {
+                $data['namespace'] = $this->functionCallNamespaces[$callId];
+            }
+            return $data;
         }
         if ($type->isFunctionResponse()) {
             $functionResponse = $part->getFunctionResponse();
@@ -567,17 +618,26 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $tools = [];
         $this->openAiFunctionNameMap = [];
         $this->clientFunctionNameMap = [];
+        $useToolSearch = $this->shouldUseToolSearch(count($functionDeclarations ?? []));
 
         if (is_array($functionDeclarations)) {
             foreach ($functionDeclarations as $functionDeclaration) {
                 $openAiName = $this->openAiFunctionName($functionDeclaration->getName());
-                $tools[] = [
+                $tool = [
                     'type' => 'function',
                     'name' => $openAiName,
                     'description' => $functionDeclaration->getDescription(),
                     'parameters' => $functionDeclaration->getParameters(),
                 ];
+                if ($useToolSearch) {
+                    $tool['defer_loading'] = true;
+                }
+                $tools[] = $tool;
             }
+        }
+
+        if ($useToolSearch) {
+            $tools[] = ['type' => 'tool_search'];
         }
 
         if ($webSearch) {
@@ -588,6 +648,61 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         }
 
         return $tools;
+    }
+
+    /**
+     * Checks whether hosted search should optimize this request's function declarations.
+     *
+     * Uses a conservative model allowlist rather than assuming every newer or specialized
+     * model supports tool search. The threshold is an experimental provider policy.
+     *
+     * @since n.e.x.t
+     *
+     * @param int $functionCount The number of declared application functions.
+     * @return bool Whether to defer functions and enable hosted search.
+     */
+    protected function shouldUseToolSearch(int $functionCount): bool
+    {
+        $options = $this->getConfig()->getCustomOptions();
+        $threshold = $options['openai_tool_search_threshold'] ?? 10;
+        if ($threshold !== false && (!is_int($threshold) || $threshold < 0)) {
+            throw new InvalidArgumentException('openai_tool_search_threshold must be a non-negative integer or false.');
+        }
+
+        // Explicit tool choice must keep its original meaning, including forced function calls.
+        if (
+            $threshold === false || $functionCount <= $threshold
+            || (isset($options['tool_choice']) && $options['tool_choice'] !== 'auto')
+            || !class_exists(ProviderData::class)
+        ) {
+            return false;
+        }
+
+        return preg_match('/^gpt-5\.4(?:-pro)?(?:-\d{4}-\d{2}-\d{2})?$/', $this->metadata()->getId()) === 1;
+    }
+
+    /**
+     * Validates an opaque hosted search item before preserving or replaying it.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, mixed> $item The provider-native item.
+     * @return void
+     * @throws InvalidArgumentException If the item is not a completed hosted search item.
+     */
+    protected function validateToolSearchItem(array $item): void
+    {
+        $type = $item['type'] ?? null;
+        if (
+            !in_array($type, ['tool_search_call', 'tool_search_output'], true)
+            || ($item['execution'] ?? null) !== 'server'
+            || !array_key_exists('call_id', $item) || $item['call_id'] !== null
+            || ($item['status'] ?? null) !== 'completed'
+            || ($type === 'tool_search_call' && !is_array($item['arguments'] ?? null))
+            || ($type === 'tool_search_output' && !is_array($item['tools'] ?? null))
+        ) {
+            throw new InvalidArgumentException('Only completed hosted tool search items can be replayed.');
+        }
     }
 
     /**
@@ -652,6 +767,25 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
                 continue;
             }
 
+            if (in_array($outputItem['type'] ?? '', ['tool_search_call', 'tool_search_output'], true)) {
+                if (!class_exists(ProviderData::class)) {
+                    throw new RuntimeException('Tool search requires SDK support for provider message data.');
+                }
+                try {
+                    $this->validateToolSearchItem($outputItem);
+                } catch (InvalidArgumentException $e) {
+                    throw ResponseException::fromInvalidData(
+                        $this->providerMetadata()->getName(),
+                        "output[{$index}]",
+                        $e->getMessage()
+                    );
+                }
+                $pendingReasoningParts[] = new MessagePart(
+                    new ProviderData($this->providerMetadata()->getId(), $outputItem)
+                );
+                continue;
+            }
+
             $candidate = $this->parseOutputItemToCandidate(
                 $outputItem,
                 $index,
@@ -660,8 +794,27 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             );
             if ($candidate !== null) {
                 $candidates[] = $candidate;
+            } elseif ($pendingReasoningParts !== [] && class_exists(ProviderData::class)) {
+                // Do not lose discovery state when an unrelated built-in item intervenes.
+                foreach ($pendingReasoningParts as $part) {
+                    if ($part->getProviderData() !== null) {
+                        $candidates[] = new Candidate(
+                            new Message(MessageRoleEnum::model(), $pendingReasoningParts),
+                            $this->parseStatusToFinishReason($status, false)
+                        );
+                        break;
+                    }
+                }
             }
             $pendingReasoningParts = [];
+        }
+
+        // A search-only response still carries conversation state, not an application tool call.
+        if ($pendingReasoningParts !== []) {
+            $candidates[] = new Candidate(
+                new Message(MessageRoleEnum::model(), $pendingReasoningParts),
+                $this->parseStatusToFinishReason($status, false)
+            );
         }
 
         $id = isset($responseData['id']) && is_string($responseData['id']) ? $responseData['id'] : '';
@@ -888,6 +1041,16 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         $part = new MessagePart($functionCall);
         $parts = $reasoningParts;
+        if (isset($outputItem['namespace']) && is_string($outputItem['namespace'])) {
+            if (!class_exists(ProviderData::class)) {
+                throw new RuntimeException('Namespaced function calls require SDK support for provider message data.');
+            }
+            $parts[] = new MessagePart(new ProviderData($this->providerMetadata()->getId(), [
+                'type' => 'function_call_namespace',
+                'call_id' => $outputItem['call_id'],
+                'namespace' => $outputItem['namespace'],
+            ]));
+        }
         $parts[] = $part;
         $message = new Message(MessageRoleEnum::model(), $parts);
 

--- a/tests/Models/OpenAiToolSearchTest.php
+++ b/tests/Models/OpenAiToolSearchTest.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\OpenAiAiProvider\Tests\Models;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ProviderData;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WordPress\AiClient\Tools\DTO\WebSearch;
+use WordPress\OpenAiAiProvider\Models\OpenAiTextGenerationModel;
+
+/**
+ * Tests provider-owned hosted tool search without a tool-search builder API.
+ *
+ * @since n.e.x.t
+ */
+class OpenAiToolSearchTest extends TestCase
+{
+    /**
+     * Tests threshold boundaries, explicit tool choice, and conservative model support.
+     *
+     * @dataProvider policyProvider
+     * @param string $modelId The model ID.
+     * @param int $count The number of functions.
+     * @param array<string, mixed> $options Provider options.
+     * @param bool $expected Whether search is expected with provider-data support.
+     */
+    public function testAutomaticPolicy(string $modelId, int $count, array $options, bool $expected): void
+    {
+        $model = $this->model($modelId, $count, $options);
+        $original = $model->getConfig()->toArray();
+        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+        $expected = $expected && class_exists(ProviderData::class);
+        $types = array_column($params['tools'], 'type');
+        $this->assertSame($expected, in_array('tool_search', $types, true));
+        $this->assertCount($count + ($expected ? 1 : 0), $params['tools']);
+        foreach ($params['tools'] as $tool) {
+            if ($tool['type'] === 'function') {
+                $this->assertSame($expected, $tool['defer_loading'] ?? false);
+            }
+        }
+        $this->assertArrayNotHasKey('openai_tool_search_threshold', $params);
+        $this->assertSame($original, $model->getConfig()->toArray());
+    }
+
+    /**
+     * Provides policy cases.
+     *
+     * @return array<string, array{string, int, array<string, mixed>, bool}> Test cases.
+     */
+    public static function policyProvider(): array
+    {
+        return [
+            'zero' => ['gpt-5.4', 0, [], false],
+            'ten eager' => ['gpt-5.4', 10, [], false],
+            'eleven deferred' => ['gpt-5.4', 11, [], true],
+            'snapshot' => ['gpt-5.4-2026-03-05', 11, [], true],
+            'pro' => ['gpt-5.4-pro', 11, [], true],
+            'old' => ['gpt-5.2', 11, [], false],
+            'unknown' => ['custom-model', 11, [], false],
+            'specialized' => ['gpt-5.4-codex', 11, [], false],
+            'opt out' => ['gpt-5.4', 11, ['openai_tool_search_threshold' => false], false],
+            'raised threshold' => ['gpt-5.4', 11, ['openai_tool_search_threshold' => 20], false],
+            'lowered threshold' => ['gpt-5.4', 1, ['openai_tool_search_threshold' => 0], true],
+            'zero with zero threshold' => ['gpt-5.4', 0, ['openai_tool_search_threshold' => 0], false],
+            'auto choice' => ['gpt-5.4', 11, ['tool_choice' => 'auto'], true],
+            'none choice' => ['gpt-5.4', 11, ['tool_choice' => 'none'], false],
+            'required choice' => ['gpt-5.4', 11, ['tool_choice' => 'required'], false],
+            'forced choice' => ['gpt-5.4', 11, ['tool_choice' => ['type' => 'function', 'name' => 'tool_0']], false],
+        ];
+    }
+
+    /**
+     * Tests invalid provider thresholds fail locally.
+     *
+     * @dataProvider invalidThresholdProvider
+     * @param mixed $threshold The invalid threshold.
+     */
+    public function testInvalidThreshold($threshold): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $model = $this->model('gpt-5.4', 11, ['openai_tool_search_threshold' => $threshold]);
+        $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+    }
+
+    /**
+     * Provides invalid thresholds.
+     *
+     * @return list<array{mixed}> Test cases.
+     */
+    public static function invalidThresholdProvider(): array
+    {
+        return [[-1], [true], ['10'], [1.5], [[]]];
+    }
+
+    /**
+     * Tests built-ins do not count toward the threshold or get deferred.
+     */
+    public function testWebSearchIsIndependent(): void
+    {
+        foreach ([10, 11] as $count) {
+            $model = $this->model('gpt-5.4', $count);
+            $model->getConfig()->setWebSearch(new WebSearch());
+            $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+            $this->assertSame(['type' => 'web_search'], $params['tools'][count($params['tools']) - 1]);
+            $this->assertSame(
+                $count > 10 && class_exists(ProviderData::class),
+                in_array('tool_search', array_column($params['tools'], 'type'), true)
+            );
+        }
+    }
+
+    /**
+     * Tests serialization and replay of hosted search, reasoning, and a namespaced mapped function.
+     */
+    public function testStatelessRoundTrip(): void
+    {
+        $this->requireProviderData();
+        $model = $this->model('gpt-5.4', 11, ['store' => false]);
+        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+        $safeName = $params['tools'][0]['name'];
+        $search = $this->searchItems();
+        $reasoning = ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [], 'encrypted_content' => 'opaque'];
+        $call = [
+            'type' => 'function_call', 'call_id' => 'call_1', 'name' => $safeName,
+            'namespace' => $safeName, 'arguments' => '{"query":"posts"}',
+        ];
+        $output = [$search[0], $reasoning, $search[1], $call];
+        $response = new Response(200, [], (string) json_encode(['id' => 'resp_1', 'output' => $output]));
+        $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
+        $this->assertCount(1, $result->getCandidates());
+        $this->assertTrue($result->getCandidates()[0]->getFinishReason()->isToolCalls());
+        $message = Message::fromArray($result->toMessage()->toArray());
+        $parts = $message->getParts();
+        $this->assertSame('plugin/tool_0', $parts[count($parts) - 1]->getFunctionCall()->getName());
+
+        // A fresh model proves that replay does not depend on instance-local search state.
+        $next = $this->model('gpt-5.4', 11, ['store' => false]);
+        $reply = new Message(MessageRoleEnum::user(), [new MessagePart(new FunctionResponse('call_1', null, ['ok']))]);
+        $nextParams = $this->invoke($next, 'prepareGenerateTextParams', [[$message, $reply]]);
+        // Object key order is immaterial; numeric output-item positions must remain unchanged.
+        $this->assertEquals($output, array_slice($nextParams['input'], 0, 4));
+        $this->assertSame('function_call_output', $nextParams['input'][4]['type']);
+        $this->assertFalse($nextParams['store']);
+    }
+
+    /**
+     * Tests search-only output is retained without requesting application execution.
+     */
+    public function testSearchOnlyOutput(): void
+    {
+        $this->requireProviderData();
+        $model = $this->model();
+        $response = new Response(200, [], (string) json_encode(['output' => $this->searchItems()]));
+        $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
+        $this->assertCount(1, $result->getCandidates());
+        $this->assertTrue($result->getCandidates()[0]->getFinishReason()->isStop());
+        $input = $this->invoke($model, 'prepareInputParam', [$result->toMessages()]);
+        $this->assertSame($this->searchItems(), $input);
+    }
+
+    /**
+     * Tests provider ownership and item-type validation reject foreign or arbitrary replay data.
+     */
+    public function testForeignProviderDataIsRejected(): void
+    {
+        $this->requireProviderData();
+        $message = new Message(MessageRoleEnum::model(), [
+            new MessagePart(new ProviderData('anthropic', $this->searchItems()[0])),
+        ]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->invoke($this->model(), 'prepareInputParam', [[$message]]);
+    }
+
+    /**
+     * Tests client-executed discovery cannot silently masquerade as hosted search.
+     */
+    public function testClientSearchResponseIsRejected(): void
+    {
+        $this->requireProviderData();
+        $item = $this->searchItems()[0];
+        $item['execution'] = 'client';
+        $item['call_id'] = 'client_1';
+        $this->expectException(ResponseException::class);
+        $response = new Response(200, [], (string) json_encode(['output' => [$item]]));
+        $this->invoke($this->model(), 'parseResponseToGenerativeAiResult', [$response]);
+    }
+
+    /**
+     * Tests arbitrary, unfinished, and user-authored opaque items cannot be replayed.
+     *
+     * @dataProvider invalidReplayProvider
+     * @param array<string, mixed> $item The invalid item.
+     * @param bool $userRole Whether the message uses a user role.
+     */
+    public function testInvalidReplay(array $item, bool $userRole = false): void
+    {
+        $this->requireProviderData();
+        $message = new Message($userRole ? MessageRoleEnum::user() : MessageRoleEnum::model(), [
+            new MessagePart(new ProviderData('openai', $item)),
+        ]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->invoke($this->model(), 'prepareInputParam', [[$message]]);
+    }
+
+    /**
+     * Provides invalid replay cases.
+     *
+     * @return list<array{array<string, mixed>, bool}> Test cases.
+     */
+    public static function invalidReplayProvider(): array
+    {
+        $valid = ['type' => 'tool_search_output', 'execution' => 'server', 'call_id' => null,
+            'status' => 'completed', 'tools' => []];
+        return [
+            [['type' => 'additional_tools', 'role' => 'developer', 'tools' => []], false],
+            [array_replace($valid, ['status' => 'in_progress']), false],
+            [array_replace($valid, ['tools' => 'invalid']), false],
+            [array_replace($valid, ['call_id' => 'client_call']), false],
+            [$valid, true],
+            [['type' => 'function_call_namespace', 'call_id' => 123], false],
+        ];
+    }
+
+    /**
+     * Tests text/search ordering and preservation across unrelated built-in output items.
+     */
+    public function testTextAndSearchOrdering(): void
+    {
+        $this->requireProviderData();
+        $search = $this->searchItems();
+        $output = [
+            ['type' => 'message', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'Before']]],
+            $search[0], $search[1], ['type' => 'web_search_call', 'id' => 'ws_1'],
+            ['type' => 'message', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'After']]],
+        ];
+        $model = $this->model();
+        $response = new Response(200, [], (string) json_encode(['output' => $output]));
+        $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
+        $input = $this->invoke($model, 'prepareInputParam', [$result->toMessages()]);
+        $this->assertCount(4, $input);
+        $this->assertSame('Before', $input[0]['content'][0]['text']);
+        $this->assertSame($search, array_slice($input, 1, 2));
+        $this->assertSame('After', $input[3]['content'][0]['text']);
+    }
+
+    /**
+     * Tests server continuation forwards only the new input supplied by the application.
+     */
+    public function testPreviousResponseIdRemainsAnOrdinaryCustomOption(): void
+    {
+        $model = $this->model('gpt-5.4', 11, ['previous_response_id' => 'resp_previous']);
+        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+        $this->assertSame('resp_previous', $params['previous_response_id']);
+        $this->assertCount(1, $params['input']);
+        $this->assertSame('input_text', $params['input'][0]['content'][0]['type']);
+    }
+
+    /**
+     * Creates a model with ordinary SDK function declarations.
+     *
+     * @param string $id The model ID.
+     * @param int $count The number of functions.
+     * @param array<string, mixed> $options Provider options.
+     * @return OpenAiTextGenerationModel The model.
+     */
+    private function model(string $id = 'gpt-5.4', int $count = 0, array $options = []): OpenAiTextGenerationModel
+    {
+        $model = new OpenAiTextGenerationModel(
+            new ModelMetadata($id, $id, [CapabilityEnum::textGeneration()], []),
+            new ProviderMetadata('openai', 'OpenAI', ProviderTypeEnum::cloud())
+        );
+        $config = new ModelConfig();
+        $functions = [];
+        for ($i = 0; $i < $count; $i++) {
+            $functions[] = new FunctionDeclaration('plugin/tool_' . $i, 'Search content ' . $i, [
+                'type' => 'object', 'properties' => ['query' => ['type' => 'string']],
+                'required' => ['query'], 'additionalProperties' => false,
+            ]);
+        }
+        $config->setFunctionDeclarations($functions);
+        $config->setCustomOptions($options);
+        $model->setConfig($config);
+        return $model;
+    }
+
+    /**
+     * Provides a simple prompt.
+     *
+     * @return list<Message> The prompt.
+     */
+    private function prompt(): array
+    {
+        return [new Message(MessageRoleEnum::user(), [new MessagePart('Find posts')])];
+    }
+
+    /**
+     * Provides documented hosted search item shapes.
+     *
+     * @return list<array<string, mixed>> The search items.
+     */
+    private function searchItems(): array
+    {
+        return [
+            ['type' => 'tool_search_call', 'execution' => 'server', 'call_id' => null,
+                'status' => 'completed', 'arguments' => ['paths' => ['posts']]],
+            ['type' => 'tool_search_output', 'execution' => 'server', 'call_id' => null,
+                'status' => 'completed', 'tools' => []],
+        ];
+    }
+
+    /**
+     * Skips replay cases on SDK versions without provider data, leaving fallback coverage active.
+     */
+    private function requireProviderData(): void
+    {
+        if (!class_exists(ProviderData::class)) {
+            $this->markTestSkipped('Requires php-ai-client provider-data support (PR #282).');
+        }
+    }
+
+    /**
+     * Invokes an existing protected model method for isolated testing.
+     *
+     * @param OpenAiTextGenerationModel $model The model.
+     * @param string $name The method name.
+     * @param list<mixed> $args The arguments.
+     * @return mixed The method result.
+     */
+    private function invoke(OpenAiTextGenerationModel $model, string $name, array $args)
+    {
+        $method = new ReflectionMethod($model, $name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($model, $args);
+    }
+}

--- a/tests/Models/OpenAiToolSearchTest.php
+++ b/tests/Models/OpenAiToolSearchTest.php
@@ -9,7 +9,6 @@ use ReflectionMethod;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\DTO\ProviderData;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
@@ -24,29 +23,27 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
 use WordPress\OpenAiAiProvider\Models\OpenAiTextGenerationModel;
 
 /**
- * Tests provider-owned hosted tool search without a tool-search builder API.
+ * Tests provider-owned policy, function annotations, and server-managed continuation.
  *
  * @since n.e.x.t
  */
 class OpenAiToolSearchTest extends TestCase
 {
     /**
-     * Tests threshold boundaries, explicit tool choice, and conservative model support.
+     * Tests automatic defaults and request-level overrides without changing the config.
      *
      * @dataProvider policyProvider
      * @param string $modelId The model ID.
      * @param int $count The number of functions.
      * @param array<string, mixed> $options Provider options.
-     * @param bool $expected Whether search is expected with provider-data support.
+     * @param bool $expected Whether all functions should be deferred.
      */
-    public function testAutomaticPolicy(string $modelId, int $count, array $options, bool $expected): void
+    public function testPolicy(string $modelId, int $count, array $options, bool $expected): void
     {
         $model = $this->model($modelId, $count, $options);
         $original = $model->getConfig()->toArray();
         $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
-        $expected = $expected && class_exists(ProviderData::class);
-        $types = array_column($params['tools'], 'type');
-        $this->assertSame($expected, in_array('tool_search', $types, true));
+        $this->assertSame($expected, in_array('tool_search', array_column($params['tools'], 'type'), true));
         $this->assertCount($count + ($expected ? 1 : 0), $params['tools']);
         foreach ($params['tools'] as $tool) {
             if ($tool['type'] === 'function') {
@@ -54,11 +51,12 @@ class OpenAiToolSearchTest extends TestCase
             }
         }
         $this->assertArrayNotHasKey('openai_tool_search_threshold', $params);
+        $this->assertArrayNotHasKey('deferredLoading', $params);
         $this->assertSame($original, $model->getConfig()->toArray());
     }
 
     /**
-     * Provides policy cases.
+     * Provides automatic policy cases.
      *
      * @return array<string, array{string, int, array<string, mixed>, bool}> Test cases.
      */
@@ -73,7 +71,10 @@ class OpenAiToolSearchTest extends TestCase
             'old' => ['gpt-5.2', 11, [], false],
             'unknown' => ['custom-model', 11, [], false],
             'specialized' => ['gpt-5.4-codex', 11, [], false],
-            'opt out' => ['gpt-5.4', 11, ['openai_tool_search_threshold' => false], false],
+            'request opt out' => ['gpt-5.4', 11, ['deferredLoading' => false], false],
+            'request opt in' => ['gpt-5.4', 1, ['deferredLoading' => true], true],
+            'empty request opt in' => ['gpt-5.4', 0, ['deferredLoading' => true], false],
+            'threshold opt out' => ['gpt-5.4', 11, ['openai_tool_search_threshold' => false], false],
             'raised threshold' => ['gpt-5.4', 11, ['openai_tool_search_threshold' => 20], false],
             'lowered threshold' => ['gpt-5.4', 1, ['openai_tool_search_threshold' => 0], true],
             'zero with zero threshold' => ['gpt-5.4', 0, ['openai_tool_search_threshold' => 0], false],
@@ -81,205 +82,201 @@ class OpenAiToolSearchTest extends TestCase
             'none choice' => ['gpt-5.4', 11, ['tool_choice' => 'none'], false],
             'required choice' => ['gpt-5.4', 11, ['tool_choice' => 'required'], false],
             'forced choice' => ['gpt-5.4', 11, ['tool_choice' => ['type' => 'function', 'name' => 'tool_0']], false],
+            'stateless storage' => ['gpt-5.4', 11, ['store' => false], false],
+            'storage opt out beats opt in' => ['gpt-5.4', 1, ['store' => false, 'deferredLoading' => true], false],
         ];
     }
 
     /**
-     * Tests invalid provider thresholds fail locally.
+     * Tests per-function annotations take precedence over defaults, but not hard opt-outs.
      *
-     * @dataProvider invalidThresholdProvider
-     * @param mixed $threshold The invalid threshold.
+     * @dataProvider annotationsProvider
+     * @param array<string, mixed> $options Request options.
+     * @param list<array<string, mixed>> $metadata Function metadata.
+     * @param list<bool> $expected Expected per-function deferral.
      */
-    public function testInvalidThreshold($threshold): void
+    public function testAnnotations(array $options, array $metadata, array $expected): void
+    {
+        $model = $this->model('gpt-5.4', count($metadata), $options, $metadata);
+        $before = $model->getConfig()->toArray();
+        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+        foreach ($expected as $index => $deferred) {
+            $this->assertSame($deferred, $params['tools'][$index]['defer_loading'] ?? false);
+            $this->assertArrayNotHasKey('metadata', $params['tools'][$index]);
+            $this->assertArrayNotHasKey('deferredLoading', $params['tools'][$index]);
+            $this->assertArrayNotHasKey('vendor', $params['tools'][$index]);
+        }
+        $this->assertSame(
+            in_array(true, $expected, true),
+            in_array('tool_search', array_column($params['tools'], 'type'), true)
+        );
+        $this->assertSame($before, $model->getConfig()->toArray());
+    }
+
+    /**
+     * Provides annotation precedence cases.
+     *
+     * @return list<array{array<string, mixed>, list<array<string, mixed>>, list<bool>}> Test cases.
+     */
+    public static function annotationsProvider(): array
+    {
+        return [
+            [[], [['deferredLoading' => true], []], [true, false]],
+            [['deferredLoading' => true], [['deferredLoading' => false], []], [false, true]],
+            [['deferredLoading' => false], [['deferredLoading' => true], []], [false, false]],
+            [['openai_tool_search_threshold' => 0], [['deferredLoading' => false], []], [false, true]],
+            [['deferredLoading' => true], [['deferredLoading' => false]], [false]],
+            [['openai_tool_search_threshold' => false], [['deferredLoading' => true]], [false]],
+            [[], [['vendor' => ['arbitrary' => true]]], [false]],
+            [['store' => false], [['deferredLoading' => true]], [false]],
+        ];
+    }
+
+    /**
+     * Tests invalid policy values fail locally rather than leaking into the wire request.
+     *
+     * @dataProvider invalidPolicyProvider
+     * @param array<string, mixed> $options Request options.
+     * @param array<string, mixed> $metadata Function metadata.
+     */
+    public function testInvalidPolicy(array $options, array $metadata): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $model = $this->model('gpt-5.4', 11, ['openai_tool_search_threshold' => $threshold]);
+        $model = $this->model('gpt-5.4', 1, $options, [$metadata]);
         $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
     }
 
     /**
-     * Provides invalid thresholds.
+     * Provides invalid request and annotation values.
      *
-     * @return list<array{mixed}> Test cases.
+     * @return list<array{array<string, mixed>, array<string, mixed>}> Test cases.
      */
-    public static function invalidThresholdProvider(): array
+    public static function invalidPolicyProvider(): array
     {
-        return [[-1], [true], ['10'], [1.5], [[]]];
+        return [
+            [['openai_tool_search_threshold' => -1], []],
+            [['openai_tool_search_threshold' => true], []],
+            [['openai_tool_search_threshold' => '10'], []],
+            [['openai_tool_search_threshold' => null], []],
+            [['deferredLoading' => 'true'], []],
+            [['deferredLoading' => null], []],
+            [[], ['deferredLoading' => 1]],
+            [[], ['deferredLoading' => null]],
+        ];
     }
 
     /**
-     * Tests built-ins do not count toward the threshold or get deferred.
+     * Tests web search stays eager and does not count toward the function threshold.
      */
     public function testWebSearchIsIndependent(): void
     {
-        foreach ([10, 11] as $count) {
-            $model = $this->model('gpt-5.4', $count);
-            $model->getConfig()->setWebSearch(new WebSearch());
-            $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
-            $this->assertSame(['type' => 'web_search'], $params['tools'][count($params['tools']) - 1]);
-            $this->assertSame(
-                $count > 10 && class_exists(ProviderData::class),
-                in_array('tool_search', array_column($params['tools'], 'type'), true)
-            );
-        }
+        $model = $this->model('gpt-5.4', 10);
+        $model->getConfig()->setWebSearch(new WebSearch());
+        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
+        $this->assertCount(11, $params['tools']);
+        $this->assertSame(['type' => 'web_search'], $params['tools'][10]);
     }
 
     /**
-     * Tests serialization and replay of hosted search, reasoning, and a namespaced mapped function.
+     * Tests discovery stays on the server while a fresh model sends only a new function result.
      */
-    public function testStatelessRoundTrip(): void
+    public function testServerManagedContinuation(): void
     {
-        $this->requireProviderData();
-        $model = $this->model('gpt-5.4', 11, ['store' => false]);
+        $model = $this->model('gpt-5.4', 1, ['deferredLoading' => true]);
         $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
         $safeName = $params['tools'][0]['name'];
-        $search = $this->searchItems();
-        $reasoning = ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [], 'encrypted_content' => 'opaque'];
-        $call = [
-            'type' => 'function_call', 'call_id' => 'call_1', 'name' => $safeName,
-            'namespace' => $safeName, 'arguments' => '{"query":"posts"}',
-        ];
-        $output = [$search[0], $reasoning, $search[1], $call];
+        $output = $this->searchItems();
+        $output[] = ['type' => 'function_call', 'call_id' => 'call_1', 'name' => $safeName,
+            'namespace' => $safeName, 'arguments' => '{"query":"posts"}'];
         $response = new Response(200, [], (string) json_encode(['id' => 'resp_1', 'output' => $output]));
         $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
         $this->assertCount(1, $result->getCandidates());
         $this->assertTrue($result->getCandidates()[0]->getFinishReason()->isToolCalls());
-        $message = Message::fromArray($result->toMessage()->toArray());
-        $parts = $message->getParts();
-        $this->assertSame('plugin/tool_0', $parts[count($parts) - 1]->getFunctionCall()->getName());
+        $parts = $result->toMessage()->getParts();
+        $this->assertCount(1, $parts);
+        $this->assertSame('plugin/tool_0', $parts[0]->getFunctionCall()->getName());
+        $this->assertSame(['continuation' => 'previous_response_id'], $result->getAdditionalData()['tool_search']);
 
-        // A fresh model proves that replay does not depend on instance-local search state.
-        $next = $this->model('gpt-5.4', 11, ['store' => false]);
+        $next = $this->model('gpt-5.4', 1, ['deferredLoading' => true, 'previous_response_id' => $result->getId()]);
         $reply = new Message(MessageRoleEnum::user(), [new MessagePart(new FunctionResponse('call_1', null, ['ok']))]);
-        $nextParams = $this->invoke($next, 'prepareGenerateTextParams', [[$message, $reply]]);
-        // Object key order is immaterial; numeric output-item positions must remain unchanged.
-        $this->assertEquals($output, array_slice($nextParams['input'], 0, 4));
-        $this->assertSame('function_call_output', $nextParams['input'][4]['type']);
-        $this->assertFalse($nextParams['store']);
+        $nextParams = $this->invoke($next, 'prepareGenerateTextParams', [[$reply]]);
+        $this->assertSame('resp_1', $nextParams['previous_response_id']);
+        $this->assertCount(1, $nextParams['input']);
+        $this->assertSame('function_call_output', $nextParams['input'][0]['type']);
+        $this->assertSame('call_1', $nextParams['input'][0]['call_id']);
+        $this->assertSame(['type' => 'tool_search'], $nextParams['tools'][1]);
+        $this->assertArrayNotHasKey('store', $nextParams); // Never override the application's storage choice.
     }
 
     /**
-     * Tests search-only output is retained without requesting application execution.
+     * Tests stateless model history or orphan function results keep functions eager.
      */
-    public function testSearchOnlyOutput(): void
+    public function testStatelessInputKeepsFunctionsEager(): void
     {
-        $this->requireProviderData();
-        $model = $this->model();
-        $response = new Response(200, [], (string) json_encode(['output' => $this->searchItems()]));
-        $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
-        $this->assertCount(1, $result->getCandidates());
+        $model = $this->model('gpt-5.4', 11);
+        $messages = [
+            new Message(MessageRoleEnum::model(), [new MessagePart('Previous answer')]),
+            new Message(MessageRoleEnum::user(), [new MessagePart(new FunctionResponse('call_1', null, ['ok']))]),
+        ];
+        foreach ($messages as $message) {
+            $params = $this->invoke($model, 'prepareGenerateTextParams', [[$message]]);
+            $this->assertCount(11, $params['tools']);
+            foreach ($params['tools'] as $tool) {
+                $this->assertArrayNotHasKey('defer_loading', $tool);
+            }
+        }
+    }
+
+    /**
+     * Tests search-only responses expose an ID and no executable search call.
+     */
+    public function testSearchOnlyResponse(): void
+    {
+        $response = new Response(200, [], (string) json_encode(['id' => 'resp_1', 'output' => $this->searchItems()]));
+        $result = $this->invoke($this->model(), 'parseResponseToGenerativeAiResult', [$response]);
+        $this->assertSame('resp_1', $result->getId());
+        $this->assertSame([], $result->toMessage()->getParts());
         $this->assertTrue($result->getCandidates()[0]->getFinishReason()->isStop());
-        $input = $this->invoke($model, 'prepareInputParam', [$result->toMessages()]);
-        $this->assertSame($this->searchItems(), $input);
     }
 
     /**
-     * Tests provider ownership and item-type validation reject foreign or arbitrary replay data.
-     */
-    public function testForeignProviderDataIsRejected(): void
-    {
-        $this->requireProviderData();
-        $message = new Message(MessageRoleEnum::model(), [
-            new MessagePart(new ProviderData('anthropic', $this->searchItems()[0])),
-        ]);
-        $this->expectException(InvalidArgumentException::class);
-        $this->invoke($this->model(), 'prepareInputParam', [[$message]]);
-    }
-
-    /**
-     * Tests client-executed discovery cannot silently masquerade as hosted search.
+     * Tests client-executed discovery and missing continuation IDs are rejected.
      */
     public function testClientSearchResponseIsRejected(): void
     {
-        $this->requireProviderData();
-        $item = $this->searchItems()[0];
-        $item['execution'] = 'client';
-        $item['call_id'] = 'client_1';
+        $items = $this->searchItems();
+        $items[0]['execution'] = 'client';
+        $items[0]['call_id'] = 'call_search';
+        $response = new Response(200, [], (string) json_encode(['id' => 'resp_1', 'output' => $items]));
         $this->expectException(ResponseException::class);
-        $response = new Response(200, [], (string) json_encode(['output' => [$item]]));
         $this->invoke($this->model(), 'parseResponseToGenerativeAiResult', [$response]);
     }
 
     /**
-     * Tests arbitrary, unfinished, and user-authored opaque items cannot be replayed.
-     *
-     * @dataProvider invalidReplayProvider
-     * @param array<string, mixed> $item The invalid item.
-     * @param bool $userRole Whether the message uses a user role.
+     * Tests search results without a response ID cannot silently lose continuation state.
      */
-    public function testInvalidReplay(array $item, bool $userRole = false): void
+    public function testMissingResponseIdIsRejected(): void
     {
-        $this->requireProviderData();
-        $message = new Message($userRole ? MessageRoleEnum::user() : MessageRoleEnum::model(), [
-            new MessagePart(new ProviderData('openai', $item)),
-        ]);
-        $this->expectException(InvalidArgumentException::class);
-        $this->invoke($this->model(), 'prepareInputParam', [[$message]]);
+        $response = new Response(200, [], (string) json_encode(['output' => $this->searchItems()]));
+        $this->expectException(ResponseException::class);
+        $this->invoke($this->model(), 'parseResponseToGenerativeAiResult', [$response]);
     }
 
     /**
-     * Provides invalid replay cases.
-     *
-     * @return list<array{array<string, mixed>, bool}> Test cases.
-     */
-    public static function invalidReplayProvider(): array
-    {
-        $valid = ['type' => 'tool_search_output', 'execution' => 'server', 'call_id' => null,
-            'status' => 'completed', 'tools' => []];
-        return [
-            [['type' => 'additional_tools', 'role' => 'developer', 'tools' => []], false],
-            [array_replace($valid, ['status' => 'in_progress']), false],
-            [array_replace($valid, ['tools' => 'invalid']), false],
-            [array_replace($valid, ['call_id' => 'client_call']), false],
-            [$valid, true],
-            [['type' => 'function_call_namespace', 'call_id' => 123], false],
-        ];
-    }
-
-    /**
-     * Tests text/search ordering and preservation across unrelated built-in output items.
-     */
-    public function testTextAndSearchOrdering(): void
-    {
-        $this->requireProviderData();
-        $search = $this->searchItems();
-        $output = [
-            ['type' => 'message', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'Before']]],
-            $search[0], $search[1], ['type' => 'web_search_call', 'id' => 'ws_1'],
-            ['type' => 'message', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'After']]],
-        ];
-        $model = $this->model();
-        $response = new Response(200, [], (string) json_encode(['output' => $output]));
-        $result = $this->invoke($model, 'parseResponseToGenerativeAiResult', [$response]);
-        $input = $this->invoke($model, 'prepareInputParam', [$result->toMessages()]);
-        $this->assertCount(4, $input);
-        $this->assertSame('Before', $input[0]['content'][0]['text']);
-        $this->assertSame($search, array_slice($input, 1, 2));
-        $this->assertSame('After', $input[3]['content'][0]['text']);
-    }
-
-    /**
-     * Tests server continuation forwards only the new input supplied by the application.
-     */
-    public function testPreviousResponseIdRemainsAnOrdinaryCustomOption(): void
-    {
-        $model = $this->model('gpt-5.4', 11, ['previous_response_id' => 'resp_previous']);
-        $params = $this->invoke($model, 'prepareGenerateTextParams', [$this->prompt()]);
-        $this->assertSame('resp_previous', $params['previous_response_id']);
-        $this->assertCount(1, $params['input']);
-        $this->assertSame('input_text', $params['input'][0]['content'][0]['type']);
-    }
-
-    /**
-     * Creates a model with ordinary SDK function declarations.
+     * Creates a model using ordinary declarations with optional generic metadata.
      *
      * @param string $id The model ID.
      * @param int $count The number of functions.
      * @param array<string, mixed> $options Provider options.
+     * @param list<array<string, mixed>> $metadata Per-function metadata.
      * @return OpenAiTextGenerationModel The model.
      */
-    private function model(string $id = 'gpt-5.4', int $count = 0, array $options = []): OpenAiTextGenerationModel
-    {
+    private function model(
+        string $id = 'gpt-5.4',
+        int $count = 0,
+        array $options = [],
+        array $metadata = []
+    ): OpenAiTextGenerationModel {
         $model = new OpenAiTextGenerationModel(
             new ModelMetadata($id, $id, [CapabilityEnum::textGeneration()], []),
             new ProviderMetadata('openai', 'OpenAI', ProviderTypeEnum::cloud())
@@ -290,7 +287,7 @@ class OpenAiToolSearchTest extends TestCase
             $functions[] = new FunctionDeclaration('plugin/tool_' . $i, 'Search content ' . $i, [
                 'type' => 'object', 'properties' => ['query' => ['type' => 'string']],
                 'required' => ['query'], 'additionalProperties' => false,
-            ]);
+            ], $metadata[$i] ?? []);
         }
         $config->setFunctionDeclarations($functions);
         $config->setCustomOptions($options);
@@ -324,17 +321,7 @@ class OpenAiToolSearchTest extends TestCase
     }
 
     /**
-     * Skips replay cases on SDK versions without provider data, leaving fallback coverage active.
-     */
-    private function requireProviderData(): void
-    {
-        if (!class_exists(ProviderData::class)) {
-            $this->markTestSkipped('Requires php-ai-client provider-data support (PR #282).');
-        }
-    }
-
-    /**
-     * Invokes an existing protected model method for isolated testing.
+     * Invokes an existing protected method for isolated testing.
      *
      * @param OpenAiTextGenerationModel $model The model.
      * @param string $name The method name.


### PR DESCRIPTION
## Summary

Revised to follow the stakeholder-approved scope: tool annotations and existing custom options, **without any new SDK message types**.

```php
$weather = new FunctionDeclaration('get_weather', 'Gets the weather', null, ['deferredLoading' => true]);
$config->setCustomOptions(['deferredLoading' => true]);
```

The provider consumes these hints locally, adds `defer_loading` only to selected function tools, and adds one hosted `tool_search` entry only when at least one function is deferred. Unknown metadata is ignored rather than copied into API requests or function parameter schemas.

Per-function annotations use the generic metadata extension in [php-ai-client #282](https://github.com/WordPress/php-ai-client/pull/282). Automatic/request-level behavior can run without that extension, including on released SDK 1.3.1.

For WordPress/php-ai-client#281.

## Policy and precedence

- Initial allowlist: `gpt-5.4`, `gpt-5.4-pro`, and dated snapshots. Unknown/specialized models keep eager functions.
- Request `deferredLoading: false` or `openai_tool_search_threshold: false` disables deferral, including individual opt-ins.
- Per-function `deferredLoading: false` keeps that function eager; `true` opts it in even below the threshold.
- Unannotated functions follow request `deferredLoading: true`, otherwise the automatic **more-than-10-function** threshold. The threshold is configurable through existing custom options.
- `store: false`, explicit non-auto tool choice, replayed model/reasoning items, or function results without a response ID keep functions eager.
- Built-in web search does not count toward the threshold and is not deferred.

## Server-managed continuation only

The earlier `ProviderData`-based replay implementation has been removed. OpenAI retains hosted search output and namespace data; the SDK receives ordinary function calls, not executable discovery calls.

Use `$result->getId()` as the next request's existing `previous_response_id` custom option and send **only new input or function results**. Do not include the previous model response/reasoning. The provider exposes an additional-data hint (`tool_search.continuation = previous_response_id`) when discovery occurs, but does not manage IDs or change `store` automatically.

Search items do not survive `toMessages()` or serialized message history. The eager fallback stops new discovery but cannot reconstruct context from an earlier searched response. After search is used, continue via its response ID or start a new conversation. Client-executed discovery is rejected. Applications with no-storage policies must keep eager loading and `store: false`.

## Implementation / review map

- `src/Models/OpenAiTextGenerationModel.php`: existing custom-option, `prepareToolsParam()`, response parsing, and `HttpTransporter` paths; annotation/default precedence, model/storage/input safeguards, hosted-output validation, response ID preservation, and ordinary function name mapping.
- `tests/Models/OpenAiToolSearchTest.php`: existing reflection-based unit-test pattern; threshold boundaries, annotation/request precedence, arbitrary-metadata isolation, invalid values, web search, stateless fallback, search-only output, rejected client discovery/missing IDs, and two-turn server-continuation plumbing with a fresh model.
- `README.md`: examples, override precedence, storage requirements, continuation workflow, and measurement plan.
- `composer.json` / `composer.lock`: development-only dependency follows the SDK metadata PR at `dec7664` to exercise annotations. Restore a released constraint before release. Existing dev-tool security updates from this PR remain; no new runtime dependency.

## Research

Checked 2026-09-09:

- [OpenAI tool search](https://developers.openai.com/api/docs/guides/tools-tool-search): hosted discovery searches declared deferred functions on compatible Responses models. Flat functions retain names/descriptions; mainly their parameter schemas are deferred. Meaningful namespaces can save more, but we do not invent grouping metadata.
- [Vercel AI SDK v7 OpenAI provider](https://ai-sdk.dev/providers/ai-sdk-providers/openai): explicit `openai.tools.toolSearch()` and per-tool `providerOptions.openai.deferLoading`, not a documented automatic count policy.
- [Vercel Anthropic provider](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic): comparable provider-owned search tools and deferred options.

## Verification

- `composer test`: **93 tests, 604 assertions, one existing metadata-test skip**.
- `composer lint`: **PHPCS and PHPStan passed**, including PHP 7.4 compatibility checks.
- `composer validate --strict`: passed.
- `composer audit`: no advisories.
- Separate released-SDK **1.3.1** smoke test: 11 ordinary functions automatically defer without a metadata accessor; request-level opt-out restores eager tools and does not leak policy parameters into the API request.
- Companion SDK: 1,202 tests / 4,366 assertions and lint passed.

## Experimental status

Remains a draft for provider experimentation and the development SDK release dependency. No paid API calls or live utility benchmarks were run. Compare eager/automatic loading at 10/11/20/50 functions with small/large schemas, measuring task success, wrong/missed tools, total tokens/cache hits, and end-to-end multi-turn latency before generalizing the policy. Streaming, stateless discovery replay, and client-executed search are outside this change.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 1h 10m and 556,600 tokens on this with the user in an interactive session.